### PR TITLE
Add the Fe bountiful bug bounty: 1 ETH open on Ethereum mainnet

### DIFF
--- a/2-mid-prizes/README.md
+++ b/2-mid-prizes/README.md
@@ -14,6 +14,7 @@ its actual state does (solved, swept, funded).
 | [Smith, Lyle & Moore Hunt #2: Glimmer](smith-lyle-moore-hunt-2-0-032btc/) | 0.031777 BTC | 2,002 | bitcoin | bip39-seed, password-pages, web-tree | insight | 2026-08-16 | open |
 | [Trithemius: Wealth in Poetry](wealth-in-poetry-0-03btc/) | 3,124,630 sats | 1,969 | bitcoin | bip39-seed, text-cipher, brainwallet | insight | 2026-08-16 | open |
 | [Arweave Puzzle #11](arweave-puzzle-11-1eth/) | 1 ETH | 1,880 | ethereum | image-stego, pixel-code, raw-private-key | insight | 2026-08-16 | open |
+| [Bountiful: the Fe compiler bug bounty](fe-lang-bountiful-compiler-bounty-1eth/) | 1 ETH | 1,880 | ethereum | smart-contract, timelock | insight | 2026-08-17 | open |
 | [Arweave Puzzle #3](arweave-puzzle-3-1000ar/) | 1,000.165838006237 AR | 1,810 | arweave | word-selection, text-cipher | insight | 2026-08-16 | open |
 | [LogicBeach: Powerful Moss](logicbeach-powerful-moss-0-54eth/) | 0.55 ETH | 1,034 | base | image-stego, bip39-seed, word-selection, smart-contract | insight | 2026-08-16 | open |
 | [Arweave Puzzle #10](arweave-puzzle-10-500ar/) | 500.02225493 AR | 905 | arweave | word-selection, text-cipher | insight | 2026-08-16 | open |

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/README.md
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/README.md
@@ -1,0 +1,182 @@
+# Bountiful: the Fe compiler bug bounty (1 ETH, [OPEN])
+
+We deploy 15-puzzle contracts on Ethereum mainnet in a start state that the published move rules cannot solve, and pay whoever can
+turn that setup into a successful claim anyway. Such a claim demonstrates a defect in the Fe
+compiler, in the challenge contract, or in the registry that holds the money. The current
+deployment went live on 2026-05-01 with 7 challenges at 0.25 ETH each and 1 ETH in the
+registry. An earlier deployment ran for almost 3 years without getting solved.
+
+## At a glance
+
+| | |
+|---|---|
+| Author | Fe language team, [fe-lang.org](https://fe-lang.org), repository [fe-lang/bountiful](https://github.com/fe-lang/bountiful) |
+| Published | 2026-05-04, announced on the project blog ([bountiful: reloaded](https://blog.fe-lang.org/posts/bountiful-reloaded/)) |
+| Prize | 1 ETH in the registry, 0.25 ETH per challenge (about $1,900 at ETH = $1,880, 2026-08-16) |
+| Chain | ethereum |
+| Escrow | the registry contract `0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D` ([etherscan](https://etherscan.io/address/0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D)); the 7 challenge contracts hold no funds themselves |
+| Last on-chain check | 2026-08-17: registry funded with 1 ETH and all 7 challenges open; `isLocked()` and `isSolved()` returned false for all 7, uncertified because no positive locked or solved control was retained |
+| Status | OPEN |
+| Puzzle type | smart-contract, timelock |
+| Target format | a reproducible transaction or calldata sequence against a current challenge or the registry that makes `claim(challenge)` succeed and transfer the prize; the normal flow requires an active lock, ordinary challenges expose `moveField(uint256)`, Game2D exposes `moveField(uint256,uint256)`, and an exploit may use raw calldata or bypass an expected registry condition |
+| Reference model | `tools/oracle.py --selftest`; useful for parity and differential checks, not certified as a solution oracle |
+| What remains | a defect nobody has found yet in fe 26.1.0 or in about 1,000 lines of published Fe |
+| Series | the retired round 2 registry is noted below |
+
+## The puzzle as published
+
+The current deployment was announced on 2026-05-04 in [bountiful:
+reloaded](https://blog.fe-lang.org/posts/bountiful-reloaded/), after the language was rewritten
+for the Fe 26.0.0 release:
+
+> We are starting with a small set of challenges, but we plan to add more over time. We are
+> also starting with small prizes of currently 0.25 ETH per challenge, but we plan to increase
+> both the number of challenges and the prize amounts as we go.
+
+The entry point is [bountiful.fe-lang.org](https://bountiful.fe-lang.org/), and I document the
+procedure in my [bounty hunting
+guide](https://github.com/fe-lang/bountiful/blob/master/doc/bounty-hunting-guide.md). I keep
+every contract source in [fe-lang/bountiful](https://github.com/fe-lang/bountiful) and hold
+office hours on Thursdays on Zulip and Twitch.
+
+## What is understood
+
+### Mechanism
+
+Each challenge stores a 4 by 4 board of the numbers 1 to 15 plus one empty field, written as
+0. Most variants expose `moveField(index)`; Game2D exposes `moveField(row, col)`. A move slides
+the selected tile into the empty field and reverts with `NotMovable` unless the two fields are
+neighbours. The reference model represents both forms with a flat index. `isSolved()` returns
+true only for `[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,0]`.
+All 7 contracts start from `[1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0]`, which is the solved
+board with tiles 14 and 15 swapped.
+
+That swap is what makes the start state unreachable. For a 4 by 4 board, the number of
+inversions among the tiles plus the row index of the empty field has a parity that no legal
+move changes: sliding a tile sideways changes neither term, and sliding it vertically changes
+the inversion count by an odd number and the empty row by one. The start board has invariant
+0 and the solved board has invariant 1, so under the published rules no sequence of
+`moveField` calls connects them, however long. A claim therefore requires a state change that
+escapes those rules.
+
+The 7 challenges implement the same rules over different Fe constructs, which is the point of
+the exercise: each one exposes a different part of the compiler.
+
+| Contract | Address | Fe construct exercised | Sourcify |
+|---|---|---|---|
+| Game | `0x046a3a4968282BaA7ad6291723873C8275434623` | `StorageMap<u256, u256>` | verified |
+| Game2D | `0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7` | `[[u256; 4]; 4]` nested arrays, `getBoard(row, col)` | verified |
+| GameEnum | `0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E` | enums, `match`, struct methods | verified |
+| GameBitboard | `0x5E987b6aADD4DFC2236D21edE6D07feb04350b06` | one `u256`, 4 bits per field | not verified |
+| GameMonadic | `0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D` | one `u256`, functional combinators | verified |
+| GameNested | `0x3dF9789634995546B0126bC28B9F9FcBCB129F18` | nested structs | verified |
+| GameTrait | `0x85b4d0B32b8a285111c244E52524B642f1A5ccFE` | `[u256; 16]` plus trait dispatch | not verified |
+
+The money sits in the registry, not in the games. Claiming has three steps, and the middle one
+exists because a winning transaction is profitable and would otherwise be copied out of the
+mempool: call `lock(challenge)` with a 0.01 ETH deposit, which reserves the challenge for the
+caller for 100 blocks and is also what the challenge move functions check on every call; solve
+the challenge within that window; call `claim(challenge)`, which calls `isSolved()` on the
+challenge and sends the prize to the caller. The lock deposit stays with the registry.
+
+### Derivation and oracle
+
+```
+python3 tools/oracle.py --selftest                       # must print SELFTEST OK
+python3 tools/oracle.py --parity                         # invariant of the deployed board
+python3 tools/oracle.py --moves 11,7,6,5                 # replay under the deployed rules
+python3 tools/oracle.py --live https://your-rpc.example                 # read boards and isSolved(), read only
+```
+
+`tools/oracle.py` is a reference model of the published move rules, not a solution oracle.
+It is useful for checking the parity invariant and for comparing a compiled challenge with the
+expected behaviour after the same calls. It models ordinary moves as flat indices; it does not
+model malformed calldata or registry exploits. Its self-test uses a synthetic board one legal
+move away from the goal as a positive witness and rejects a non-adjacent move as a negative
+control. An actual bounty candidate must be run against the compiled contracts and confirmed
+by a successful `claim(challenge)`.
+
+### Established facts
+
+1. The registry `0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D` holds 1 ETH, and each of the 7
+   challenges is registered at 0.25 ETH and is open. `isLocked()` returned false for all 7;
+   that negative state is uncertified because I retained no known locked control. I read these
+   values on 2026-08-17 with `cast balance`, `getPrizeAmount(address)`,
+   `isOpenChallenge(address)` and `isLocked(address)`. The nominal total of 1.75 ETH is
+   larger than the balance, so the registry pays the first 4 claims and the 5th reverts until
+   it is funded again.
+2. All 7 challenges hold a zero balance and report the same board,
+   `[1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0]`. `isSolved()` returned false for all 7; that
+   negative state is uncertified because I retained no known solved contract as a positive
+   RPC control. I read all 16 fields and called `isSolved()` on each contract on 2026-08-17
+   (`python3 tools/oracle.py --live <rpc-url>`).
+3. The lock deposit is 0.01 ETH and the lock period is 100 blocks, about 20 minutes.
+   Confirmed 2026-08-17 with `getLockDeposit()` and the constant `LOCK_PERIOD` in the
+   published source.
+4. The registry was created on 2026-05-01 by `0xaD0Ad88D27F49fe6a0c73FdB743f6B7304a2C357`
+   with 1 ETH sent at deployment, followed by 7 `registerChallenge` calls in the same minutes.
+   Confirmed from the creation transaction
+   [`0xb74abeb76c6436d54df5f8022703580955b29cc8377d358672a2f153962d0822`](https://etherscan.io/tx/0xb74abeb76c6436d54df5f8022703580955b29cc8377d358672a2f153962d0822).
+5. The compiler pinned for the current round is fe 26.1.0, and Sourcify reports a runtime
+   `match` for 6 of the 8 deployed contracts, with the language recorded as Fe. `GameBitboard` and
+   `GameTrait` have no verified source there. Confirmed 2026-08-17 against the Sourcify v2
+   API.
+7. `claim(address)` marks the challenge closed before it calls `isSolved()` on it, and pays
+   with a raw call that forwards the remaining gas to the caller. `withdraw()` is restricted
+   to the admin and reverts while any lock is active. Read from the published registry source.
+
+## What has been tested
+
+Full ledger in [analysis/tested.md](analysis/tested.md). Summary:
+
+| Hypothesis | Space | Method | Result | Witness | Date |
+|---|---|---|---|---|---|
+| The published rules connect the start board to the solved board | all move sequences of any length | invariant of the start board compared with the solved board, computed by the reference model | 0 match, the two differ | yes: a synthetic board one legal move from the goal keeps the same invariant and is solved by the same replay code | 2026-08-17 |
+| Somebody already solved a challenge of the current deployment | full transaction history of the registry since 2026-05-01 | every transaction to the registry inspected | 0 locks, 0 claims, one reverted `withdraw()` by a non-admin | uncertified: no positive transaction-history control is retained here | 2026-08-17 |
+| Round 2 was claimed at some point in its 2 years and 10 months | full internal transaction history of the round 2 registry | every value-bearing internal transfer inspected | 0 claims, only the admin withdrawal | uncertified: no positive transfer-history control is retained here | 2026-08-17 |
+
+No candidate move sequence has been tested against the current 7 contracts, and no compiler
+level search has been run. The negatives above are about the state of the chain, not about
+the space of possible defects.
+
+## Open leads, ranked
+
+1. **Re-audit the hand-written data in each challenge** (hours). Each of the 7 contracts
+   contains hand-written material that implements the same rules in different forms: an
+   adjacency table encoded as decimal digits, index arithmetic for the 2D variant, and bit
+   offsets for the packed variants. Reading those files against the reference rules is the
+   cheapest bounded check. What would confirm it: any input where a contract accepts a move
+   the reference rules reject.
+2. **Differential testing against a reference implementation** (hours). Build the workspace
+   with fe 26.1.0, then drive each challenge and `tools/oracle.py` with the same random move
+   sequences and compare the full board after every call. Divergence is the finding; agreement
+   over a large sample bounds the search rather than closing it.
+3. **Rebuild the two contracts that Sourcify does not cover** (hours). `GameBitboard` and
+   `GameTrait` are the two challenges without verified sources. Compiling them from the tagged
+   repository with the pinned compiler and comparing the runtime bytecode to the deployed code
+   either verifies them or shows that what is deployed is not what is published.
+4. **Attack the registry rather than a game** (hours). The prize is paid by `claim`, which
+   closes the challenge before the external `isSolved()` call and then forwards all remaining
+   gas to the caller in a raw call. The pot is shared by 7 challenges but funded for 4 claims,
+   so the accounting between prizes, lock deposits and the balance is worth reading closely.
+
+Full notes: [analysis/leads.md](analysis/leads.md).
+
+## Files in this folder
+
+| Path | What it is |
+|---|---|
+| `data/challenges.json` | the 7 deployed challenges, their prizes, boards, `getBoard` selectors and `isSolved()` results, read from the chain on 2026-08-17 |
+| `analysis/tested.md` | the complete negatives ledger |
+| `analysis/leads.md` | full notes behind the 4 ranked leads |
+| `tools/oracle.py` | reference model for parity and differential checks; its self-test does not certify bounty candidates |
+
+## Sources
+
+- Fe language team, "bountiful: reloaded", blog.fe-lang.org, 2026-05-04: https://blog.fe-lang.org/posts/bountiful-reloaded/
+- Fe language team, "bountiful: round #2", blog.fe-lang.org, 2023-01-11: https://blog.fe-lang.org/posts/bountiful-round-2/
+- Bountiful platform, live challenge list, 2026-08-17: https://bountiful.fe-lang.org/
+- Bounty hunting guide, fe-lang/bountiful, 2026-08-17: https://github.com/fe-lang/bountiful/blob/master/doc/bounty-hunting-guide.md
+- Registry and challenge sources, fe-lang/bountiful, 2026-08-17: https://github.com/fe-lang/bountiful
+- Round 2 admin withdrawal, Etherscan, 2025-11-04: https://etherscan.io/tx/0xdd5188f6bb7a2fb5fab1b170213c3ad107dab20407e900128525adb92e36077e
+- Sourcify verification of the Game challenge, compiler fe 26.1.0, 2026-08-17: https://sourcify.dev/server/v2/contract/1/0x046a3a4968282BaA7ad6291723873C8275434623

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/analysis/leads.md
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/analysis/leads.md
@@ -1,0 +1,70 @@
+# Leads (full notes)
+
+The "Open leads, ranked" section of the folder's `README.md` shows the ranked list; this file
+carries the full notes behind each entry. Order leads by cost to test, then by expected value.
+
+## 1. Re-audit the hand-written data in each challenge
+
+- **Cost**: hours
+- **What it is**: every challenge encodes the same rules twice, once in its move logic and
+  once in a table or a set of offsets written out by hand. The current contracts store the
+  adjacency table as decimal digits packed into a `u256` (`1 + 4 * 1000 + 666 * 1000000 + ...`,
+  with 666 as the marker for a missing neighbour), the 2D variant recomputes row and column
+  from an index, and the packed variants address 4 bit fields inside one word. Each of those
+  is a place where a single wrong constant could make the deployed behaviour diverge.
+- **Why it ranks here**: it needs no build and no chain access, and the material is about 1,000
+  lines in a public repository.
+- **What would confirm it**: an input where a contract accepts a move that the reference rules
+  in `tools/oracle.py` reject, or where the two disagree on the resulting board.
+- **What would kill it**: a line by line reconciliation of all 7 tables against the reference
+  adjacency, with the offsets recomputed rather than read.
+- **Status**: open
+
+## 2. Differential testing against a reference implementation
+
+- **Cost**: hours
+- **What it is**: build the workspace with fe 26.1.0 and Foundry as my guide
+  describes, then drive both a locally deployed challenge and `tools/oracle.py` with the same
+  random sequences of `moveField` calls, comparing all 16 fields after every call. Include
+  calls that should revert, since a missing revert is as much a finding as a wrong board.
+- **Why it ranks here**: it covers the compiler as well as the contract, which lead 1 does
+  not, at the cost of a build and a test harness. It has not been run publicly against the
+  current deployment.
+- **What would confirm it**: any divergence between the contract and the reference after the
+  same call sequence.
+- **What would kill it**: nothing kills it outright. A large sample without divergence bounds
+  the defect to the parts of the compiler that these 7 contracts do not exercise, which is
+  useful to state with the sample size.
+- **Status**: open
+
+## 3. Rebuild the two contracts Sourcify does not cover
+
+- **Cost**: hours
+- **What it is**: `GameBitboard` (`0x5E987b6aADD4DFC2236D21edE6D07feb04350b06`) and
+  `GameTrait` (`0x85b4d0B32b8a285111c244E52524B642f1A5ccFE`) are the two deployed contracts
+  with no verified source on Sourcify, while the other 6 match. Compile them from the tagged
+  repository with the pinned compiler and compare the runtime bytecode with the deployed code.
+- **Why it ranks here**: it is bounded and mechanical, and it either removes a gap in what a
+  hunter can trust or shows that the deployed code differs from the published code, which
+  would itself be the finding.
+- **What would confirm it**: a byte difference between the local build and the deployed
+  runtime code that is not explained by metadata or constructor arguments.
+- **What would kill it**: a byte for byte match, or a later Sourcify verification by the
+  author.
+- **Status**: open
+
+## 4. Attack the registry rather than a game
+
+- **Cost**: hours
+- **What it is**: the prize logic sits in `claim(address)`. It requires an active lock owned
+  by the caller, marks the challenge closed before calling `isSolved()` on it, and then sends
+  the prize with a raw call that forwards the remaining gas to the caller. The registry also
+  holds 1 ETH against 7 challenges registered at 0.25 ETH each, and keeps every lock deposit.
+- **Why it ranks here**: it is the smallest contract in the system and the only one that moves
+  money, but the ordering already follows checks, effects, interactions, so this is a reading
+  exercise rather than a known weakness.
+- **What would confirm it**: a call sequence where the registry pays without the challenge
+  reporting a solve, or pays twice for one challenge.
+- **What would kill it**: a full reading of the registry source against its compiled output,
+  covering the lock accounting and the two raw calls.
+- **Status**: open

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/analysis/tested.md
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/analysis/tested.md
@@ -1,0 +1,18 @@
+# Tested (full negatives ledger)
+
+The summary table in the folder's `README.md` shows the highlights; this file is the complete
+record. Add one row per hypothesis family tested, in the order tested. Never remove a row; if
+a hypothesis is retested with a different method, add a new row rather than editing the old
+one.
+
+Every row here is about the state of the chain and the published rules. No candidate move
+sequence has been run against the 7 deployed contracts yet, and no compiler level search has
+been run, so nothing below narrows the space of possible defects.
+
+| Hypothesis | Space (N) | Method | Result | Witness | Rate | Date |
+|---|---|---|---|---|---|---|
+| The published move rules connect `[1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0]` to the solved board | all sequences of any length, the reachable half of the 16! board states | computed the invariant (inversions among the tiles plus the row of the empty field, modulo 2) for both boards with `tools/oracle.py --parity`, which is unchanged by every move the adjacency table allows | 0 match: start board invariant 0, solved board invariant 1 | yes: a synthetic board one legal move from the goal keeps the same invariant and is solved by the same replay code | single evaluation | 2026-08-17 |
+| A challenge of the current deployment has already been locked or claimed | every transaction sent to the registry `0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D` since its creation on 2026-05-01 | listed the full transaction history and classified each by selector | 0 `lock(address)` calls, 0 `claim(address)` calls; 9 transactions total: the creation with 1 ETH, 7 `registerChallenge` calls by the admin, and one `withdraw()` on 2026-07-15 from `0xdF04A38f0d60C913b70B60255139e3f12CB43B94` that reverted because the caller is not the admin | uncertified: no positive transaction-history control is retained here | full history, 4 months | 2026-08-17 |
+| Round 2 was claimed at some point between 2023-01-11 and its retirement | every internal transaction of the round 2 registry `0x76eB86d4f92901f2af0d10feDDdA0B3B4630700D` | listed all internal transfers and kept the ones carrying value | 0 payouts; the single value-bearing transfer is the admin withdrawal of 3.1 ETH on 2025-11-04 | uncertified: no positive transfer-history control is retained here | full history, 2 years 10 months | 2026-08-17 |
+| The deployed boards differ from the board stated in the announcement, or a contract already reports solved | 7 contracts, 16 fields plus `isSolved()` each, 119 reads | read `getBoard` from every contract and called `isSolved()` over an Ethereum RPC endpoint (`tools/oracle.py --live`), including the two argument getter used by `Game2D` | 0 differences and 0 solved: all 7 report `[1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0]` and return `isSolved()` false | uncertified: no known solved contract was read through the same RPC path as a positive control | 119 reads | 2026-08-17 |
+| The deployed code is the published code | 8 contracts | queried the Sourcify v2 API for each address on chain 1 | 6 of 8 report a runtime `match` with the language recorded as Fe and the compiler as fe 26.1.0; `GameBitboard` and `GameTrait` have no verified source there, which is not evidence of a difference, only an absence of the check | uncertified: no local rebuild was compared against the deployed runtime bytecode | 8 queries | 2026-08-17 |

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/data/challenges.json
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/data/challenges.json
@@ -1,0 +1,146 @@
+{
+  "comment": "Round 3 of the Fe bountiful bug bounty, Ethereum mainnet. Read from the chain on 2026-08-17: getPrizeAmount(address) and isOpenChallenge(address) on the registry, every board field and isSolved() on each challenge. The false isSolved() results are uncertified because no known solved contract was retained as a positive RPC control.",
+  "chain_id": 1,
+  "registry": "0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D",
+  "registry_balance_wei": "1000000000000000000",
+  "lock_deposit_wei": "10000000000000000",
+  "lock_period_blocks": 100,
+  "start_board": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    15,
+    14,
+    0
+  ],
+  "start_board_packed": "0x0EFDCBA987654321",
+  "solved_board": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    0
+  ],
+  "solved_board_packed": "0x0FEDCBA987654321",
+  "challenges": [
+    {
+      "name": "Game",
+      "address": "0x046a3a4968282BaA7ad6291723873C8275434623",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "StorageMap<u256, u256>",
+      "sourcify": "verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    },
+    {
+      "name": "Game2D",
+      "address": "0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "[[u256; 4]; 4] nested arrays",
+      "sourcify": "verified",
+      "get_board": {
+        "signature": "getBoard(uint256,uint256)",
+        "selector": "0x58e4f026",
+        "args": "row, col"
+      }
+    },
+    {
+      "name": "GameEnum",
+      "address": "0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "enums, match, struct methods",
+      "sourcify": "verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    },
+    {
+      "name": "GameBitboard",
+      "address": "0x5E987b6aADD4DFC2236D21edE6D07feb04350b06",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "single u256, bit packing",
+      "sourcify": "not-verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    },
+    {
+      "name": "GameMonadic",
+      "address": "0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "single u256, functional combinators",
+      "sourcify": "verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    },
+    {
+      "name": "GameNested",
+      "address": "0x3dF9789634995546B0126bC28B9F9FcBCB129F18",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "nested structs",
+      "sourcify": "verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    },
+    {
+      "name": "GameTrait",
+      "address": "0x85b4d0B32b8a285111c244E52524B642f1A5ccFE",
+      "prize_wei": "250000000000000000",
+      "open": true,
+      "is_solved": false,
+      "fe_feature": "[u256; 16] plus trait dispatch",
+      "sourcify": "not-verified",
+      "get_board": {
+        "signature": "getBoard(uint256)",
+        "selector": "0x45e09e54",
+        "args": "index"
+      }
+    }
+  ]
+}

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/puzzle.json
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/puzzle.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "slug": "fe-lang-bountiful-compiler-bounty-1eth",
+  "title": "Bountiful: the Fe compiler bug bounty",
+  "tier": "mid",
+  "status": "open",
+  "dead_end_reason": null,
+  "series": "bountiful",
+  "author": {
+    "name": "Fe language team",
+    "handles": ["github:fe-lang", "github:cburgdorf", "zulip:fe-lang.zulipchat.com"],
+    "url": "https://fe-lang.org"
+  },
+  "published": { "date": "2026-05-04", "url": "https://blog.fe-lang.org/posts/bountiful-reloaded/" },
+  "chain": "ethereum",
+  "prize": {
+    "amount": 1,
+    "asset": "ETH",
+    "usd_estimate": 1880,
+    "usd_snapshot": "2026-08-16",
+    "note": "the registry holds 1 ETH and each of the 7 registered challenges carries a 0.25 ETH prize, so the pot pays the first 4 claims and the 5th would revert; the 1 ETH balance, not the 1.75 ETH nominal total, is what the chain can pay today"
+  },
+  "addresses": [
+    { "address": "0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D", "chain": "ethereum", "role": "escrow", "label": "BountyRegistry, round 3", "explorer": "https://etherscan.io/address/0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D", "expected": "1 ETH", "verified_on": "2026-08-17", "verified_state": "funded-unspent" },
+    { "address": "0x046a3a4968282BaA7ad6291723873C8275434623", "chain": "ethereum", "role": "contract", "label": "Game", "explorer": "https://etherscan.io/address/0x046a3a4968282BaA7ad6291723873C8275434623", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7", "chain": "ethereum", "role": "contract", "label": "Game2D", "explorer": "https://etherscan.io/address/0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E", "chain": "ethereum", "role": "contract", "label": "GameEnum", "explorer": "https://etherscan.io/address/0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0x5E987b6aADD4DFC2236D21edE6D07feb04350b06", "chain": "ethereum", "role": "contract", "label": "GameBitboard", "explorer": "https://etherscan.io/address/0x5E987b6aADD4DFC2236D21edE6D07feb04350b06", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D", "chain": "ethereum", "role": "contract", "label": "GameMonadic", "explorer": "https://etherscan.io/address/0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0x3dF9789634995546B0126bC28B9F9FcBCB129F18", "chain": "ethereum", "role": "contract", "label": "GameNested", "explorer": "https://etherscan.io/address/0x3dF9789634995546B0126bC28B9F9FcBCB129F18", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0x85b4d0B32b8a285111c244E52524B642f1A5ccFE", "chain": "ethereum", "role": "contract", "label": "GameTrait", "explorer": "https://etherscan.io/address/0x85b4d0B32b8a285111c244E52524B642f1A5ccFE", "expected": "0 ETH, prize held by the registry", "verified_on": "2026-08-17", "verified_state": "zero-balance-contract" },
+    { "address": "0x76eB86d4f92901f2af0d10feDDdA0B3B4630700D", "chain": "ethereum", "role": "contract", "label": "BountyRegistry, round 2, retired", "explorer": "https://etherscan.io/address/0x76eB86d4f92901f2af0d10feDDdA0B3B4630700D", "expected": "0 ETH, the admin withdrew 3.1 ETH on 2025-11-04", "verified_on": "2026-08-17", "verified_state": "swept" }
+  ],
+  "puzzle_type": ["smart-contract", "timelock"],
+  "target_format": "a reproducible transaction or calldata sequence against one current challenge or the registry that makes claim(challenge) succeed and transfer the prize; the normal flow requires an active lock, ordinary challenges expose moveField(uint256), Game2D exposes moveField(uint256,uint256), and an exploit may use raw calldata or bypass an expected registry condition",
+  "derivation": {
+    "summary": "the board starts with tiles 14 and 15 swapped, which puts it in the half of the state space the published move rules cannot leave; a successful claim therefore needs a defect in the Fe compiler, in the challenge contract, or in the registry that escapes or bypasses those rules",
+    "oracle": "tools/oracle.py",
+    "oracle_certified": false,
+    "certified_against": ""
+  },
+  "difficulty_left": "insight",
+  "difficulty_note": "the 7 contracts are small and their sources are published, so nothing here is compute bound; what is missing is a defect nobody has spotted yet, in a compiler at version 26.1.0 or in about 1,000 lines of hand-written Fe",
+  "tested_total": { "candidates": 0, "families": 5, "certified": false },
+  "leads": [
+    { "rank": 1, "title": "re-audit the hand-written data in each challenge: adjacency tables, index arithmetic, bit field offsets", "cost": "hours", "status": "open" },
+    { "rank": 2, "title": "differential testing: run random move sequences against each compiled challenge and against a reference implementation, compare after every call", "cost": "hours", "status": "open" },
+    { "rank": 3, "title": "GameBitboard and GameTrait are not verified on Sourcify: rebuild them with fe 26.1.0 and compare the runtime bytecode against the deployed code", "cost": "hours", "status": "open" },
+    { "rank": 4, "title": "attack the registry rather than a game: claim() closes the challenge before the external isSolved() call and pays with a raw call forwarding all gas", "cost": "hours", "status": "open" }
+  ],
+  "solutions": [],
+  "artifacts": [],
+  "sources": [
+    { "title": "bountiful: reloaded", "url": "https://blog.fe-lang.org/posts/bountiful-reloaded/", "date": "2026-05-04", "archived": null },
+    { "title": "bountiful: round #2", "url": "https://blog.fe-lang.org/posts/bountiful-round-2/", "date": "2023-01-11", "archived": null },
+    { "title": "Bountiful platform website with the live challenge list", "url": "https://bountiful.fe-lang.org/", "date": "2026-08-17", "archived": null },
+    { "title": "Bounty hunting guide, fe-lang/bountiful", "url": "https://github.com/fe-lang/bountiful/blob/master/doc/bounty-hunting-guide.md", "date": "2026-08-17", "archived": null },
+    { "title": "Challenge and registry sources, fe-lang/bountiful", "url": "https://github.com/fe-lang/bountiful", "date": "2026-08-17", "archived": null },
+    { "title": "Round 2 admin withdrawal of 3.1 ETH", "url": "https://etherscan.io/tx/0xdd5188f6bb7a2fb5fab1b170213c3ad107dab20407e900128525adb92e36077e", "date": "2025-11-04", "archived": null },
+    { "title": "Sourcify verification of the Game challenge, compiler fe 26.1.0", "url": "https://sourcify.dev/server/v2/contract/1/0x046a3a4968282BaA7ad6291723873C8275434623", "date": "2026-08-17", "archived": null }
+  ],
+  "third_party_material": "no third-party articles or dumps; my own blog posts, repository sources and documentation, quoted in short excerpts with links, plus on-chain data I read directly from Ethereum mainnet",
+  "last_updated": "2026-08-17"
+}

--- a/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/tools/oracle.py
+++ b/2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/tools/oracle.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+oracle.py -- reference model for the bountiful Fe compiler bug bounty.
+
+Purpose:
+    Replay a sequence of moveField(index) calls against a reference implementation of the
+    published 15-puzzle rules. This is useful for parity checks and differential testing, but
+    it is not a solution oracle: an actual bounty candidate must exploit behaviour that differs
+    from these rules and must be tested against the compiled challenge contract.
+
+Usage (run from the puzzle folder):
+    python3 tools/oracle.py --selftest
+    python3 tools/oracle.py --moves 11,7,6,5
+    python3 tools/oracle.py --board 1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0 --moves 11,7
+    python3 tools/oracle.py --parity
+    python3 tools/oracle.py --live https://your-rpc.example
+
+Output:
+    MATCH reference rules after <n> moves  the sequence reaches the solved board
+    NO MATCH <reason>                    it does not
+    Move replay exits 0 on MATCH and 1 on NO MATCH. Successful --selftest, --parity and
+    --live checks exit 0; argument, input and RPC errors are non-zero.
+
+This tool never signs, sends or broadcasts anything. --live only reads.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FOLDER = os.path.dirname(HERE)
+DATA = os.path.join(FOLDER, "data")
+
+SOLVED_BOARD = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0]
+IS_SOLVED_SELECTOR = "0x64d98f6e"
+
+# shared/game_util.fe, ADJACENCY: for an empty field at index i, the fields that may move
+# into it. This is the plain 4 by 4 grid adjacency.
+ADJACENCY_DEPLOYED = {
+    0: [1, 4],
+    1: [0, 2, 5],
+    2: [1, 3, 6],
+    3: [2, 7],
+    4: [0, 5, 8],
+    5: [1, 4, 6, 9],
+    6: [2, 5, 7, 10],
+    7: [3, 6, 11],
+    8: [4, 9, 12],
+    9: [5, 8, 10, 13],
+    10: [6, 9, 11, 14],
+    11: [7, 10, 15],
+    12: [8, 13],
+    13: [9, 12, 14],
+    14: [10, 13, 15],
+    15: [11, 14],
+}
+
+
+def load_json(name):
+    with open(os.path.join(DATA, name), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_board(board):
+    if len(board) != 16:
+        raise ValueError("a board needs 16 values")
+    if sorted(board) != list(range(16)):
+        raise ValueError("a board must contain every value from 0 through 15 exactly once")
+    return board
+
+
+def start_board():
+    return validate_board(list(load_json("challenges.json")["start_board"]))
+
+
+def parse_board(text):
+    text = text.strip()
+    if text.lower().startswith("0x"):
+        packed = int(text, 16)
+        if packed >= 1 << 64:
+            raise ValueError("a packed board must fit in 64 bits")
+        board = [(packed >> (4 * i)) & 0xF for i in range(16)]
+    else:
+        board = [int(x.strip()) for x in text.split(",")]
+    return validate_board(board)
+
+
+def empty_index(board):
+    return board.index(0)
+
+
+def apply_move(board, index, table):
+    """One moveField(index) call. Returns the new board, or raises ValueError like the
+    contract's NotMovable / InvalidIndex reverts."""
+    if index < 0 or index > 15:
+        raise ValueError("InvalidIndex: %d" % index)
+    e = empty_index(board)
+    if index not in table[e]:
+        raise ValueError("NotMovable: field %d is not listed for an empty field at %d" % (index, e))
+    out = list(board)
+    out[e] = out[index]
+    out[index] = 0
+    return out
+
+
+def is_solved(board):
+    return board == SOLVED_BOARD
+
+
+def inversion_parity(board):
+    """Parity of the number of inversions among the tiles, ignoring the empty field."""
+    tiles = [v for v in board if v != 0]
+    inversions = 0
+    for i in range(len(tiles)):
+        for j in range(i + 1, len(tiles)):
+            if tiles[i] > tiles[j]:
+                inversions += 1
+    return inversions % 2
+
+
+def solvability_invariant(board):
+    """For a 4 by 4 board the quantity (inversions + row of the empty field) is unchanged by
+    every legal move, so two boards with different values cannot be reached from each other.
+    Returns that value modulo 2."""
+    return (inversion_parity(board) + (empty_index(board) // 4)) % 2
+
+
+def replay(board, moves, table):
+    for index in moves:
+        board = apply_move(board, index, table)
+    return board
+
+
+def read_live_states(rpc_url):
+    """Read the board and isSolved() result of every deployed challenge. Read only."""
+    import urllib.request
+
+    def call(to, data):
+        payload = json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "eth_call",
+            "params": [{"to": to, "data": data}, "latest"],
+        }).encode()
+        req = urllib.request.Request(
+            rpc_url, data=payload,
+            headers={"Content-Type": "application/json", "User-Agent": "open-crypto-puzzles-oracle"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read().decode())
+        if "error" in body:
+            raise RuntimeError(body["error"])
+        return int(body["result"], 16)
+
+    out = {}
+    for entry in load_json("challenges.json")["challenges"]:
+        getter = entry["get_board"]
+        selector = getter["selector"]
+        board = []
+        for i in range(16):
+            if getter["args"] == "row, col":
+                args = "%064x%064x" % (i // 4, i % 4)
+            else:
+                args = "%064x" % i
+            board.append(call(entry["address"], selector + args))
+        try:
+            validate_board(board)
+        except ValueError as exc:
+            raise RuntimeError(
+                "%s returned an invalid board %s: %s" % (entry["name"], board, exc)
+            ) from exc
+        solved_raw = call(entry["address"], IS_SOLVED_SELECTOR)
+        if solved_raw not in (0, 1):
+            raise RuntimeError("isSolved() returned a non-boolean value for %s" % entry["name"])
+        out[entry["name"]] = {"board": board, "is_solved": bool(solved_raw)}
+    return out
+
+
+def selftest():
+    def require(condition, message):
+        if not condition:
+            raise AssertionError(message)
+
+    start = start_board()
+    goal = list(SOLVED_BOARD)
+
+    require(is_solved(goal), "the solved board must be recognised as solved")
+    require(not is_solved(start), "the deployed start board must not be recognised as solved")
+
+    # The published rules cannot connect the two boards: the invariant differs.
+    require(
+        solvability_invariant(start) != solvability_invariant(goal),
+        "the deployed start board must sit in the other half of the state space",
+    )
+
+    # Positive witness: move one tile out of the solved board, then replay the reverse move
+    # through the same code used for user-supplied sequences.
+    one_move_away = apply_move(goal, 14, ADJACENCY_DEPLOYED)
+    require(not is_solved(one_move_away), "the witness board must not already be solved")
+    require(
+        solvability_invariant(one_move_away) == solvability_invariant(goal),
+        "the invariant must keep a known legal one-move pair in the same component",
+    )
+    require(
+        is_solved(replay(one_move_away, [15], ADJACENCY_DEPLOYED)),
+        "the reference replay must find the known one-move solution",
+    )
+
+    # Negative control: a non-adjacent move must be rejected.
+    rejected = False
+    try:
+        replay(goal, [0], ADJACENCY_DEPLOYED)
+    except ValueError:
+        rejected = True
+    require(rejected, "the reference rules must reject a non-adjacent move")
+
+    print("SELFTEST OK")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="reference model for the bountiful bug bounty")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--selftest", action="store_true", help="run the self-test and exit")
+    mode.add_argument("--moves", default=None, help="comma separated moveField indices")
+    mode.add_argument("--parity", action="store_true", help="print the solvability invariant and exit")
+    mode.add_argument(
+        "--live", default=None, metavar="RPC_URL",
+        help="read live boards and isSolved() results, then exit",
+    )
+    parser.add_argument(
+        "--board", default=None,
+        help="16 comma separated values, or a packed hex board; only for --moves or --parity",
+    )
+    args = parser.parse_args()
+
+    if args.board is not None and (args.selftest or args.live):
+        parser.error("--board may only be used with --moves or --parity")
+
+    if args.selftest:
+        return selftest()
+
+    try:
+        board = parse_board(args.board) if args.board else start_board()
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if args.live:
+        try:
+            live_states = read_live_states(args.live)
+        except (KeyError, OSError, RuntimeError, ValueError) as exc:
+            parser.error("--live failed: %s" % exc)
+        for name, live in sorted(live_states.items()):
+            board = live["board"]
+            print("%-13s %s  invariant=%d  isSolved()=%s" % (
+                name, board, solvability_invariant(board), str(live["is_solved"]).lower(),
+            ))
+        return 0
+
+    if args.parity:
+        print("board      %s" % board)
+        print("invariant  %d" % solvability_invariant(board))
+        print("solved     %d" % solvability_invariant(SOLVED_BOARD))
+        print("reachable  %s" % ("yes" if solvability_invariant(board) == solvability_invariant(SOLVED_BOARD) else "no"))
+        return 0
+
+    try:
+        moves = [int(x) for x in args.moves.split(",") if x.strip() != ""]
+    except ValueError:
+        parser.error("--moves must be a comma separated list of integers")
+    try:
+        final = replay(board, moves, ADJACENCY_DEPLOYED)
+    except ValueError as exc:
+        print("NO MATCH %s" % exc)
+        return 1
+
+    if is_solved(final):
+        print("MATCH reference rules after %d moves" % len(moves))
+        return 0
+    print("NO MATCH board is %s after %d moves" % (final, len(moves)))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ on-chain right now.
 | Asset | Locked in unsolved puzzles | Approx. value |
 |---|---|---|
 | Bitcoin | 9.80 BTC | $617,000 |
-| Ethereum | 12.21 ETH | $23,000 |
+| Ethereum | 13.21 ETH | $25,000 |
 | Arweave | 1,900 AR | $3,400 |
 | Stablecoins | 306 USDT + 166 USDC | $500 |
-| **Total** | **across 33 funded puzzles** | **$644,000** |
+| **Total** | **across 34 funded puzzles** | **$646,000** |
 
 Checked 2026-08-16 at BTC $63,000, ETH $1,880, AR $1.81. Prices and balances move; verify each escrow yourself.
 <!-- totals:end -->
@@ -81,6 +81,7 @@ grouped by prize, is in the tables below.
 | [Smith, Lyle & Moore Hunt #2: Glimmer](2-mid-prizes/smith-lyle-moore-hunt-2-0-032btc/) | 0.031777 BTC | 2,002 | bitcoin | bip39-seed, password-pages, web-tree | insight | 2026-08-16 | open |
 | [Trithemius: Wealth in Poetry](2-mid-prizes/wealth-in-poetry-0-03btc/) | 3,124,630 sats | 1,969 | bitcoin | bip39-seed, text-cipher, brainwallet | insight | 2026-08-16 | open |
 | [Arweave Puzzle #11](2-mid-prizes/arweave-puzzle-11-1eth/) | 1 ETH | 1,880 | ethereum | image-stego, pixel-code, raw-private-key | insight | 2026-08-16 | open |
+| [Bountiful: the Fe compiler bug bounty](2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth/) | 1 ETH | 1,880 | ethereum | smart-contract, timelock | insight | 2026-08-17 | open |
 | [Arweave Puzzle #3](2-mid-prizes/arweave-puzzle-3-1000ar/) | 1,000.165838006237 AR | 1,810 | arweave | word-selection, text-cipher | insight | 2026-08-16 | open |
 | [LogicBeach: Powerful Moss](2-mid-prizes/logicbeach-powerful-moss-0-54eth/) | 0.55 ETH | 1,034 | base | image-stego, bip39-seed, word-selection, smart-contract | insight | 2026-08-16 | open |
 | [Arweave Puzzle #10](2-mid-prizes/arweave-puzzle-10-500ar/) | 500.02225493 AR | 905 | arweave | word-selection, text-cipher | insight | 2026-08-16 | open |

--- a/docs/verify-funding.md
+++ b/docs/verify-funding.md
@@ -74,6 +74,14 @@ received anything at all. This is different from "swept": the funds were never t
 first place, often because a follow-up announcement never materialized, or the amount quoted
 publicly does not match anything on chain.
 
+## What "zero-balance-contract" looks like
+
+A deployed contract that is part of a puzzle but is not itself an escrow can be expected to
+hold no prize funds. Its manifest uses `zero-balance-contract` so the funding checker records
+that expectation without calling it `unfunded` or `swept`. The EVM check requires both a zero
+balance and non-empty bytecode, rather than inferring funding history from the account nonce.
+Empty bytecode or a later positive balance is reported as drift and makes the check fail.
+
 ## What "custodial" means
 
 Some puzzles do not lock funds in a wallet you can check directly. Instead, a platform or a

--- a/puzzles.json
+++ b/puzzles.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "big": 7,
-    "mid": 22,
+    "mid": 23,
     "small": 4,
     "solved": 2,
     "dead-end": 11
@@ -1851,6 +1851,221 @@
       "third_party_material": "clues/kitten.jpeg is the author-published puzzle image, byte-identical to the original, sha256 recorded in artifacts[]; no wordlists or third-party bulk data included, only my own derived candidate counts",
       "last_updated": "2026-08-16",
       "folder": "2-mid-prizes/corey-phillips-kitten-passphrase-1msats"
+    },
+    {
+      "schema_version": 1,
+      "slug": "fe-lang-bountiful-compiler-bounty-1eth",
+      "title": "Bountiful: the Fe compiler bug bounty",
+      "tier": "mid",
+      "status": "open",
+      "dead_end_reason": null,
+      "series": "bountiful",
+      "author": {
+        "name": "Fe language team",
+        "handles": [
+          "github:fe-lang",
+          "github:cburgdorf",
+          "zulip:fe-lang.zulipchat.com"
+        ],
+        "url": "https://fe-lang.org"
+      },
+      "published": {
+        "date": "2026-05-04",
+        "url": "https://blog.fe-lang.org/posts/bountiful-reloaded/"
+      },
+      "chain": "ethereum",
+      "prize": {
+        "amount": 1,
+        "asset": "ETH",
+        "usd_estimate": 1880,
+        "usd_snapshot": "2026-08-16",
+        "note": "the registry holds 1 ETH and each of the 7 registered challenges carries a 0.25 ETH prize, so the pot pays the first 4 claims and the 5th would revert; the 1 ETH balance, not the 1.75 ETH nominal total, is what the chain can pay today"
+      },
+      "addresses": [
+        {
+          "address": "0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D",
+          "chain": "ethereum",
+          "role": "escrow",
+          "label": "BountyRegistry, round 3",
+          "explorer": "https://etherscan.io/address/0x71fB6afcD98c5BD611712ad4b8D314EF729aa69D",
+          "expected": "1 ETH",
+          "verified_on": "2026-08-17",
+          "verified_state": "funded-unspent"
+        },
+        {
+          "address": "0x046a3a4968282BaA7ad6291723873C8275434623",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "Game",
+          "explorer": "https://etherscan.io/address/0x046a3a4968282BaA7ad6291723873C8275434623",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "Game2D",
+          "explorer": "https://etherscan.io/address/0xE959e7ecA1afCa6cf2Bf8b07e25Da355b6C8E8c7",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "GameEnum",
+          "explorer": "https://etherscan.io/address/0xfb5423aDfBAC65ac675845Bb4FEBf8aeC128272E",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0x5E987b6aADD4DFC2236D21edE6D07feb04350b06",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "GameBitboard",
+          "explorer": "https://etherscan.io/address/0x5E987b6aADD4DFC2236D21edE6D07feb04350b06",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "GameMonadic",
+          "explorer": "https://etherscan.io/address/0x86B7AEce1503242fED29E593FAEde3b7b00a5a1D",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0x3dF9789634995546B0126bC28B9F9FcBCB129F18",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "GameNested",
+          "explorer": "https://etherscan.io/address/0x3dF9789634995546B0126bC28B9F9FcBCB129F18",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0x85b4d0B32b8a285111c244E52524B642f1A5ccFE",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "GameTrait",
+          "explorer": "https://etherscan.io/address/0x85b4d0B32b8a285111c244E52524B642f1A5ccFE",
+          "expected": "0 ETH, prize held by the registry",
+          "verified_on": "2026-08-17",
+          "verified_state": "zero-balance-contract"
+        },
+        {
+          "address": "0x76eB86d4f92901f2af0d10feDDdA0B3B4630700D",
+          "chain": "ethereum",
+          "role": "contract",
+          "label": "BountyRegistry, round 2, retired",
+          "explorer": "https://etherscan.io/address/0x76eB86d4f92901f2af0d10feDDdA0B3B4630700D",
+          "expected": "0 ETH, the admin withdrew 3.1 ETH on 2025-11-04",
+          "verified_on": "2026-08-17",
+          "verified_state": "swept"
+        }
+      ],
+      "puzzle_type": [
+        "smart-contract",
+        "timelock"
+      ],
+      "target_format": "a reproducible transaction or calldata sequence against one current challenge or the registry that makes claim(challenge) succeed and transfer the prize; the normal flow requires an active lock, ordinary challenges expose moveField(uint256), Game2D exposes moveField(uint256,uint256), and an exploit may use raw calldata or bypass an expected registry condition",
+      "derivation": {
+        "summary": "the board starts with tiles 14 and 15 swapped, which puts it in the half of the state space the published move rules cannot leave; a successful claim therefore needs a defect in the Fe compiler, in the challenge contract, or in the registry that escapes or bypasses those rules",
+        "oracle": "tools/oracle.py",
+        "oracle_certified": false,
+        "certified_against": ""
+      },
+      "difficulty_left": "insight",
+      "difficulty_note": "the 7 contracts are small and their sources are published, so nothing here is compute bound; what is missing is a defect nobody has spotted yet, in a compiler at version 26.1.0 or in about 1,000 lines of hand-written Fe",
+      "tested_total": {
+        "candidates": 0,
+        "families": 5,
+        "certified": false
+      },
+      "leads": [
+        {
+          "rank": 1,
+          "title": "re-audit the hand-written data in each challenge: adjacency tables, index arithmetic, bit field offsets",
+          "cost": "hours",
+          "status": "open"
+        },
+        {
+          "rank": 2,
+          "title": "differential testing: run random move sequences against each compiled challenge and against a reference implementation, compare after every call",
+          "cost": "hours",
+          "status": "open"
+        },
+        {
+          "rank": 3,
+          "title": "GameBitboard and GameTrait are not verified on Sourcify: rebuild them with fe 26.1.0 and compare the runtime bytecode against the deployed code",
+          "cost": "hours",
+          "status": "open"
+        },
+        {
+          "rank": 4,
+          "title": "attack the registry rather than a game: claim() closes the challenge before the external isSolved() call and pays with a raw call forwarding all gas",
+          "cost": "hours",
+          "status": "open"
+        }
+      ],
+      "solutions": [],
+      "artifacts": [],
+      "sources": [
+        {
+          "title": "bountiful: reloaded",
+          "url": "https://blog.fe-lang.org/posts/bountiful-reloaded/",
+          "date": "2026-05-04",
+          "archived": null
+        },
+        {
+          "title": "bountiful: round #2",
+          "url": "https://blog.fe-lang.org/posts/bountiful-round-2/",
+          "date": "2023-01-11",
+          "archived": null
+        },
+        {
+          "title": "Bountiful platform website with the live challenge list",
+          "url": "https://bountiful.fe-lang.org/",
+          "date": "2026-08-17",
+          "archived": null
+        },
+        {
+          "title": "Bounty hunting guide, fe-lang/bountiful",
+          "url": "https://github.com/fe-lang/bountiful/blob/master/doc/bounty-hunting-guide.md",
+          "date": "2026-08-17",
+          "archived": null
+        },
+        {
+          "title": "Challenge and registry sources, fe-lang/bountiful",
+          "url": "https://github.com/fe-lang/bountiful",
+          "date": "2026-08-17",
+          "archived": null
+        },
+        {
+          "title": "Round 2 admin withdrawal of 3.1 ETH",
+          "url": "https://etherscan.io/tx/0xdd5188f6bb7a2fb5fab1b170213c3ad107dab20407e900128525adb92e36077e",
+          "date": "2025-11-04",
+          "archived": null
+        },
+        {
+          "title": "Sourcify verification of the Game challenge, compiler fe 26.1.0",
+          "url": "https://sourcify.dev/server/v2/contract/1/0x046a3a4968282BaA7ad6291723873C8275434623",
+          "date": "2026-08-17",
+          "archived": null
+        }
+      ],
+      "third_party_material": "no third-party articles or dumps; my own blog posts, repository sources and documentation, quoted in short excerpts with links, plus on-chain data I read directly from Ethereum mainnet",
+      "last_updated": "2026-08-17",
+      "folder": "2-mid-prizes/fe-lang-bountiful-compiler-bounty-1eth"
     },
     {
       "schema_version": 1,

--- a/schema/puzzle.schema.json
+++ b/schema/puzzle.schema.json
@@ -243,10 +243,37 @@
               "swept",
               "unfunded",
               "contract-holds-funds",
+              "zero-balance-contract",
               "unknown"
             ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "verified_state": {
+                  "const": "zero-balance-contract"
+                }
+              },
+              "required": ["verified_state"]
+            },
+            "then": {
+              "required": ["expected"],
+              "properties": {
+                "chain": {
+                  "enum": ["ethereum", "base"]
+                },
+                "role": {
+                  "const": "contract"
+                },
+                "expected": {
+                  "pattern": "^0+(?:\\.0+)?\\s"
+                }
+              }
+            }
+          }
+        ]
       }
     },
     "puzzle_type": {

--- a/tools/check_escrows.py
+++ b/tools/check_escrows.py
@@ -18,9 +18,15 @@ Input:
     puzzles.json if present at the repository root, otherwise every <tier>/<slug>/puzzle.json.
 
 Output:
-    One printed row per address: slug, label, address, expected, observed, spent, verdict.
-    Exit code 1 if any address that a manifest claims is "funded-unspent" is observed as
-    swept or unfunded. Network errors are printed as ERROR and never counted as a sweep.
+    One printed row per address: slug, label, address, expected, observed state and verdict,
+    followed by chain-specific details.
+    Exit code 1 if an address claimed as "funded-unspent" is observed as swept or unfunded,
+    or if a "zero-balance-contract" no longer has both bytecode and a zero balance. Network
+    errors are printed as ERROR and never counted as drift.
+
+    A deployed EVM contract that is not itself an escrow may use the manifest state
+    "zero-balance-contract". For that state, the checker verifies both a zero balance and
+    non-empty bytecode without claiming that the contract ever held prize funds.
 """
 
 import argparse
@@ -28,6 +34,7 @@ import json
 import os
 import sys
 from datetime import date
+from decimal import Decimal, InvalidOperation
 
 import requests
 
@@ -37,7 +44,11 @@ TIERS = ["1-big-prizes", "2-mid-prizes", "3-small-prizes", "4-solved", "archive/
 TIMEOUT = 15
 RETRIES = 1  # one retry after the first attempt, so two attempts total
 
-ETH_RPC_ENDPOINTS = ["https://eth.drpc.org", "https://cloudflare-eth.com"]
+ETH_RPC_ENDPOINTS = [
+    "https://eth.drpc.org",
+    "https://cloudflare-eth.com",
+    "https://ethereum-rpc.publicnode.com",
+]
 BASE_RPC_ENDPOINT = "https://mainnet.base.org"
 
 
@@ -109,6 +120,30 @@ def check_evm(address, endpoints):
     return "ERROR", f"network error: {last_exc}"
 
 
+def check_zero_balance_evm_contract(address, endpoints):
+    last_exc = None
+    for url in endpoints:
+        try:
+            balance_hex = _eth_rpc(url, "eth_getBalance", [address, "latest"])
+            code = _eth_rpc(url, "eth_getCode", [address, "latest"])
+            balance_wei = int(balance_hex, 16)
+            code_empty = code in ("0x", "0x0")
+            code_bytes = 0 if code_empty else (len(code.removeprefix("0x")) + 1) // 2
+            if balance_wei > 0:
+                return "funded-unspent", (
+                    f"balance_wei={balance_wei} code_bytes={code_bytes} (via {url})"
+                )
+            if code_empty:
+                return "unfunded", f"balance_wei=0 code=empty (via {url})"
+            return "zero-balance-contract", (
+                f"balance_wei=0 code_bytes={code_bytes} (via {url})"
+            )
+        except Exception as exc:
+            last_exc = exc
+            continue
+    return "ERROR", f"network error: {last_exc}"
+
+
 def check_ethereum(address):
     return check_evm(address, ETH_RPC_ENDPOINTS)
 
@@ -133,6 +168,9 @@ def check_arweave(address):
 def check_address(entry):
     chain = entry.get("chain", "")
     address = entry.get("address", "")
+    if is_zero_balance_contract_entry(entry):
+        endpoints = ETH_RPC_ENDPOINTS if chain == "ethereum" else [BASE_RPC_ENDPOINT]
+        return check_zero_balance_evm_contract(address, endpoints)
     if chain == "bitcoin":
         return check_bitcoin(address)
     if chain == "ethereum":
@@ -144,6 +182,25 @@ def check_address(entry):
     if chain == "solana":
         return "SKIPPED", "Solana is not queried automatically; check https://solscan.io/account/<address> by hand."
     return "ERROR", f"unknown chain: {chain}"
+
+
+def expected_amount_is_zero(entry):
+    token = entry.get("expected", "").strip().split(maxsplit=1)
+    if not token:
+        return False
+    try:
+        return Decimal(token[0].replace(",", "")) == 0
+    except InvalidOperation:
+        return False
+
+
+def is_zero_balance_contract_entry(entry):
+    return (
+        entry.get("chain") in ("ethereum", "base")
+        and entry.get("role") == "contract"
+        and expected_amount_is_zero(entry)
+        and entry.get("verified_state") == "zero-balance-contract"
+    )
 
 
 def load_puzzles(slug_filter=None):
@@ -235,6 +292,9 @@ def main():
                 verdict = "ERROR (network, not a verdict)"
             elif state == "SKIPPED":
                 verdict = "SKIPPED"
+            elif claimed_state == "zero-balance-contract" and state != claimed_state:
+                verdict = f"DRIFT: manifest says zero-balance-contract, chain says {state}"
+                any_drift = True
             elif claimed_state == "funded-unspent" and state in ("swept", "unfunded"):
                 verdict = f"DRIFT: manifest says funded-unspent, chain says {state}"
                 any_drift = True
@@ -249,7 +309,7 @@ def main():
             update_manifest(puzzle, results_by_address)
 
     if any_drift:
-        print("\nAt least one address that a manifest claims is funded-unspent is now swept or unfunded.")
+        print("\nAt least one critical manifest state no longer matches the chain.")
         sys.exit(1)
     sys.exit(0)
 


### PR DESCRIPTION
Bountiful is a permissionless bug bounty run by the Fe language team. Seven 15-puzzle contracts sit on Ethereum mainnet in an unreachable start state. The registry pays 0.25 ETH for a successful claim caused by a defect in the Fe compiler, a challenge contract, or the registry.

Read from the chain on 2026-08-17: the registry holds 1 ETH, all seven challenges returned open, every isLocked() and isSolved() call returned false, and every board starts at
[1,2,3,4,5,6,7,8,9,10,11,12,13,15,14,0]. The negative lock and solve states are uncertified because I retained no positive locked or solved RPC control. The balance covers the first four of the seven nominal 0.25 ETH prizes.

The folder focuses on the current Fe 26.1.0 deployment. It also records an uncertified transaction-history negative: I found no round 2 claim before its funds were withdrawn in 2025.

tools/oracle.py is a reference model for parity and differential testing, not a certified solution oracle. Actual exploits must be reproduced against the compiled contracts and confirmed by a successful claim.

The funding checker now distinguishes zero-balance challenge contracts from swept escrows by requiring both a zero balance and non-empty bytecode.

Disclosure: I am on the Fe team, so this folder covers a bounty I help publish and fund. This folder passes all 15 repository QA checks.