### PR TITLE
Add the r/bitcoinpuzzles threads to the GSMG.io sources

### DIFF
--- a/1-big-prizes/gsmg-io-5btc-puzzle/README.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/README.md
@@ -250,4 +250,6 @@ Full notes: [analysis/leads.md](analysis/leads.md).
 - First transfer to the second address, mempool.space, 2020-05-11: https://mempool.space/tx/2aa9a4a90be819d5122d70c993280785a0508f163521e7b38cebb4db0b071b13
 - Second transfer to the second address (public key source), mempool.space, 2024-04-24: https://mempool.space/tx/88cdb3cdca12b471551b1b26188508a14ca5fd8a415223ffb7c190381c9b9df3
 - bitcointalk topic 5532424, "Need help Puzzle GSMG.IO 5BTC": https://bitcointalk.org/index.php?topic=5532424.0
+- Reddit discussion, r/bitcoinpuzzles: https://www.reddit.com/r/bitcoinpuzzles/comments/bf7siz/gsmgio_5_btc_puzzle_challenge/
+- Reddit discussion, r/bitcoinpuzzles: https://www.reddit.com/r/bitcoinpuzzles/comments/dfwcqk/gsmgio_5_btc_puzzle/
 - Community-maintained stage documentation: https://github.com/puzzlehunt/gsmgio-5btc-puzzle

--- a/1-big-prizes/gsmg-io-5btc-puzzle/clues/author-posts.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/clues/author-posts.md
@@ -20,6 +20,14 @@ Community discussion thread, active since 2025-02-18, including several solvers'
 notes on the stage chain. Used here only to corroborate the public stage order, not
 quoted directly.
 
+## Reddit, r/bitcoinpuzzles
+
+https://www.reddit.com/r/bitcoinpuzzles/comments/bf7siz/gsmgio_5_btc_puzzle_challenge/
+
+https://www.reddit.com/r/bitcoinpuzzles/comments/dfwcqk/gsmgio_5_btc_puzzle/
+
+Two community discussion threads, also linked from the community repository below.
+
 ## Community repository
 
 https://github.com/puzzlehunt/gsmgio-5btc-puzzle


### PR DESCRIPTION
The folder cites bitcointalk and the community repository but not the two r/bitcoinpuzzles threads that the community README links. Added them to clues/author-posts.md and to the Sources list, marked as provenance since nothing in the folder is sourced from them.

validate.py --folder 1-big-prizes/gsmg-io-5btc-puzzle gives the same result before and after: 13 passed, 2 failed. The two failures are the jsonschema package not being installed and the oracle self-test, and both fail identically on main here, so they look like missing packages on my side rather than anything in the diff.

Unrelated to this PR, but in case it is useful: I re-checked the escrow state on 2026-08-18 against mempool.space and blockstream.info and both agree with the figures in the README, 1.25634510 BTC and 3.75055310 BTC.
