### PR TITLE
gsmg.io: tools/oracle.py derives the AES key with the wrong digest

### DIFF
--- a/1-big-prizes/gsmg-io-5btc-puzzle/README.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/README.md
@@ -144,11 +144,13 @@ stages do provide real blobs with known passwords for the decryption half:
 2. **AES decrypt**: the puzzle's own phase-2 blob, whose password is the known stage
    answer `sha256("causality")`, decrypts to its known plaintext under
    EVP_BytesToKey with SHA-256, and produces no valid PKCS7 padding under a wrong
-   password. A third check asserts that EVP_BytesToKey with MD5 fails on the same
-   blob. This replaces an earlier synthetic round-trip vector, which could not detect
-   a wrong digest because it encrypted and decrypted with the same derivation; that
-   is how the file came to ship MD5, which fails on every blob in this puzzle whose
-   password is known (see `analysis/tested.md` section 10).
+   password. A third check asserts that EVP_BytesToKey with MD5 fails on that
+   particular blob. This replaces an earlier synthetic round-trip vector, which could
+   not detect a wrong digest because it encrypted and decrypted with the same
+   derivation. Note that the puzzle uses both digests: phases 2 and 3 use SHA-256,
+   while the Cosmic Duality blob uses MD5 (see `analysis/tested.md` sections 10 and
+   11). Since the small blob's password is unknown, its digest cannot be determined,
+   and the oracle tries both.
 3. The published blob itself is confirmed to decode to the documented shape: 96
    bytes, header `Salted__`, salt `3ab585348552415d`.
 

--- a/1-big-prizes/gsmg-io-5btc-puzzle/README.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/README.md
@@ -84,7 +84,10 @@ I and O removed, reduces to exactly 256 symbols drawn from a 23-letter alphabet.
 Every attempt so far to turn that 256-symbol object directly into a 32-byte private
 key has failed (see "What has been tested").
 
-The final page separately publishes a small OpenSSL "Salted__" AES-256-CBC blob (96
+The SalPhaseIon page,
+`gsmg.io/89727c598b9cd1cf8873f27cb7057f050645ddb6a7a157a110239ac0152f6a32`, reached by
+hashing the text of the first puzzle page rather than through the Architect Choice,
+publishes a small OpenSSL "Salted__" AES-256-CBC blob (96
 bytes total: 8-byte header, 8-byte salt `3ab585348552415d`, 80 bytes of ciphertext,
 enough for a 64-byte plaintext after PKCS7 padding). The password is reported to be
 `sha256(X).hexdigest()` for an answer string X the solver must find; this repository
@@ -127,8 +130,9 @@ and which this repository has no access to.
 
 ### Certified against
 
-`tools/oracle.py --selftest` certifies the pipeline's two halves independently,
-since X is unsolved and no end-to-end known-good vector exists:
+`tools/oracle.py --selftest` certifies the pipeline's two halves independently. X is
+unsolved, so no vector exists for the answer string itself, but the puzzle's earlier
+stages do provide real blobs with known passwords for the decryption half:
 
 1. **Address derivation**: the escrow's own uncompressed public key, recovered from
    its 2024-04-24 spending transaction
@@ -137,12 +141,14 @@ since X is unsolved and no end-to-end known-good vector exists:
    hashes byte-exact to `1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe`. This certifies the
    HASH160-plus-Base58Check half of the pipeline against a real, independently
    checkable fact.
-2. **AES decrypt**: a self-made OpenSSL-compatible blob (a 64-byte test plaintext,
-   encrypted with a test password using the same EVP_BytesToKey MD5 key derivation
-   and AES-256-CBC scheme) decrypts back to the exact original plaintext with the
-   correct password, and produces no valid PKCS7 padding with a wrong password.
-   This is a synthetic vector, not one from the puzzle, since no real password is
-   known.
+2. **AES decrypt**: the puzzle's own phase-2 blob, whose password is the known stage
+   answer `sha256("causality")`, decrypts to its known plaintext under
+   EVP_BytesToKey with SHA-256, and produces no valid PKCS7 padding under a wrong
+   password. A third check asserts that EVP_BytesToKey with MD5 fails on the same
+   blob. This replaces an earlier synthetic round-trip vector, which could not detect
+   a wrong digest because it encrypted and decrypted with the same derivation; that
+   is how the file came to ship MD5, which fails on every blob in this puzzle whose
+   password is known (see `analysis/tested.md` section 10).
 3. The published blob itself is confirmed to decode to the documented shape: 96
    bytes, header `Salted__`, salt `3ab585348552415d`.
 
@@ -186,6 +192,8 @@ Full ledger in [analysis/tested.md](analysis/tested.md). Summary:
 | A substring of the object is a Base58Check string to decode | 123,728 candidates | Base58Check checksum, then address comparison | 0 match, 0 valid checksum | yes | 2026-07-28 |
 | Large "Dualite" blob read directly as bits, no password | 59,269 candidates | direct address comparison | 0 match | yes | 2026-07-30 |
 | Literal password strings harvested from 1,017 archived scripts, replayed under a fixed appearance filter | 116,043 candidates | AES decrypt then address comparison | 0 match | yes | 2026-07-28 |
+| Small-blob pipeline swept for the first time: puzzle vocabulary, stage texts and their word windows, "last words" readings, live-page prose, the system word list, and the confirmed stage passwords | 1,358,577 candidates | corrected oracle, AES decrypt then address comparison | 0 match | yes | 2026-08-19 |
+| Key derivation: the shipped oracle used EVP_BytesToKey/MD5, which fails on both puzzle blobs whose passwords are known | not a sweep | decrypt phase-2 and phase-3 blobs under both digests | MD5 refuted, SHA-256 confirmed | yes | 2026-08-19 |
 
 Cumulative: approximately 335.7 million candidates tested as direct reductions of
 the 256-symbol object or the large blob, all negative; a further 116,043-candidate

--- a/1-big-prizes/gsmg-io-5btc-puzzle/analysis/leads.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/analysis/leads.md
@@ -102,3 +102,40 @@ decrypted under any tested password (`analysis/tested.md` row 6). No lead above
 targets it directly with a password sweep, because no password-generation
 hypothesis for it currently has more support than any other; leads 2 to 4 are the
 routes most likely to produce one.
+
+## 6. Re-run anything that was tested through the shipped oracle
+
+Not a hypothesis about the puzzle, but the precondition for trusting any result from this
+folder's own tool. Until 2026-08-19 `tools/oracle.py` derived the AES key with
+EVP_BytesToKey/MD5, which fails on every blob in this puzzle whose password is known
+(`analysis/tested.md` section 10). Any candidate previously pushed through it was compared
+against a key the puzzle does not produce.
+
+What would confirm it: nothing further; the derivation is now certified against the
+phase-2 blob, and the selftest asserts that MD5 fails on the same blob.
+What this changes: negatives obtained through the shipped oracle are void rather than
+negative. Section 9's sweeps have been re-run under the corrected derivation. Anyone who
+swept this pipeline independently before this date should assume the same.
+Cost: the pipeline runs at about 76,800 candidates per second per core, so re-running a
+past sweep costs roughly what the original cost.
+
+## 7. The small blob is on the SalPhaseIon page, not the final page
+
+The README described the small blob as published on the final page reached after the
+Architect Choice. It is published on the SalPhaseIon page,
+`gsmg.io/89727c598b9cd1cf8873f27cb7057f050645ddb6a7a157a110239ac0152f6a32`, reached by a
+different route: hashing the text of the first puzzle page. Verified by reassembling the
+blob from that page's own single-character token run, where the two 64-character halves sit
+at token positions 916 and 1020 with a 40-character run of a and b between them; reading
+that run as a=0, b=1 gives the five bytes `enter`.
+
+Why it matters as a lead, not just a correction: the password should be sought in the
+instructions on the page that carries the blob. That page decodes to exactly two
+directives, `lastwordsbeforearchichoice` and `thispassword`, which read together as a
+statement that the last words before the Architect Choice are this blob's password.
+What would confirm it: a reading of those "last words" that matches.
+What would kill it: exhausting the candidate texts. Section 9's last-N-word sweeps are a
+first pass over the texts currently held and are negative; they do not exhaust the
+instruction, because the phase-1 page is an image whose own wording is not transcribed
+anywhere in this folder.
+Cost: hours, and it needs sources rather than compute.

--- a/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
@@ -220,6 +220,65 @@ assume one digest cover only half the space. Section 9's sweeps assumed SHA-256 
 negative only for SHA-256.
 
 
+## 12. The Half / Better Half derivation, reproduced end to end
+
+Not a candidate sweep. The Cosmic Duality plaintext from section 11 carries the rest of
+the chain, and the whole of it reproduces here from primary sources.
+
+Method, applied to the 1327-byte plaintext:
+
+1. Read as a bitstream, row-major, into a 103 x 103 binary matrix. 1327 bytes is 10,616
+   bits and 103 x 103 is 10,609, leaving 7 padding bits; the fit is exact.
+2. Take row_sums[i] (ones per row) and col_sums[i] (ones per column).
+3. secondary[i] = chr((row_sums[i] + col_sums[(i + 7) mod 103]) and 0xFF), giving 103
+   characters whose ordinals lie in 80..117, i.e. exactly 38 distinct symbols.
+4. Decode those 103 characters as a base-38 number with digit = ord(ch) - 80, giving 68
+   bytes: 32 for "Half", 32 for "Better half", and 4 trailing.
+
+Result: the 103-character secondary string reproduces the value published in
+puzzlehunt/gsmgio-5btc-puzzle#72 exactly, and the two 32-byte values reproduce the keys
+published in that repository's issue #79, which derive to:
+
+| | compressed | uncompressed |
+|---|---|---|
+| Half | 1JG648yaB7Wp2dpUfcZoRSD4q35oq47vCu | 15E3pcDDXSKhvi3CLVhRTHEgd8dbVKvSZg |
+| Better half | 145ZQ9siLrsXBKf465wjdyQYAP5dRwhRhQ | 1FhbJnrdq1FmeiXrpTqnpQ8jvYV7naze96 |
+
+The private keys are already public in that issue and are not repeated here; the four
+addresses above are enough to check the derivation. All four were empty when checked on
+2026-08-19. Witness: yes, the reproduction from the live page is the witness.
+Date: 2026-08-19.
+
+## 13. The trailing 4 bytes complete the phase-2 variable table
+
+The 4 bytes left over from section 12's base-38 decode are `fc0c1b02`. Read as signed
+bytes they are -4, 12, 27, 2.
+
+Those are the four unknowns in the table the phase-2 page prints as
+`# X 2 S H 4 Y 0 Q B 15 #`. Two of its variables were already public: S = 32, from the
+Klingon arithmetic the page gives (cha' + vagh x jav = 2 + 5 x 6), and B = -16, from the
+Intel processor model number the page gives ((4i)^2). X, H, Y and Q had no published
+values. With the trailing bytes supplying X = -4, H = 12, Y = 27 and Q = 2, the table
+resolves in full to:
+
+    -4, 2, 32, 12, 4, 27, 0, 2, -16, 15
+
+This closes an object that had been partially solved since 2019 and connects two stages
+that were previously unrelated in this folder's account: the phase-2 riddle table and the
+tail of the Cosmic Duality decode.
+
+Tested as password material for the small blob (decimal joins with several separators,
+absolute values, hex forms, the raw byte string, the concatenated and XORed key material,
+each under both key-derivation digests): 32 forms, 0 match.
+
+Provenance note: the same reading appears in puzzlehunt/gsmgio-5btc-puzzle#88. That issue
+also asserts a hidden "Salted__" blob at offset 158 of the Cosmic Duality plaintext with
+salt 5bbd88ac32481bca, which is false: there is no such marker anywhere in the 1327 bytes
+and those eight salt bytes occur at no offset, checked against a file whose SHA-256
+matches the one that issue itself publishes. The table reading is recorded here because it
+was independently verified, not because it was posted.
+
+
 ## Cumulative
 
 Across the 7 completed hypothesis families above (rows 1 to 7), 335,724,615

--- a/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
@@ -124,15 +124,81 @@ scripts constructed dynamically at run time (concatenations, permutations, chain
 derivations). Those dynamic patterns are the subject of the open lead ranked first
 in the README; this row is why that lead is ranked first rather than closed.
 
+## 9. The small-blob pipeline, first sweeps
+
+The rows above test the 256-symbol object and the large blob. None of them tests the
+small-blob pipeline `tools/oracle.py` implements (candidate answer to sha256 password to
+AES decrypt to 32-byte key to address). These rows are the first sweeps of it.
+
+Every sweep below was first run against the shipped oracle, which derived the AES key with
+EVP_BytesToKey/MD5. That derivation is wrong for this puzzle (see section 10). The counts
+and results here are from the re-run under EVP_BytesToKey/SHA-256; the earlier results are
+void rather than negative, and are not reported.
+
+Method: candidates pushed through the corrected oracle with no filter ahead of the address
+comparison. PKCS7 padding rejects about 255 of every 256 wrong passwords before any
+elliptic-curve work, measured at 0.35 percent of random passwords producing valid padding
+against 0.39 percent expected, which is what makes this pipeline cheap to sweep. Measured
+rate 76,803 candidates per second per core.
+
+| Configuration | Candidates | Result |
+|---|---|---|
+| Puzzle vocabulary and stage names, each in four cases and reversed | 273 | 0 match |
+| Ordered pairs of that vocabulary | 74,256 | 0 match |
+| Suffixes and prefixes of the Architect message | 4,174 | 0 match |
+| Every contiguous word window up to 14 words of the Architect message, the VIC plaintext, and the phase-2 and phase-3 decryptions | 49,808 | 0 match |
+| Last-N-word readings of every stage text, in the conventions the pages state | 5,608 | 0 match |
+| Live-page prose re-fetched from the site, SalPhaseIon and Cosmic Duality terms | 17,125 | 0 match |
+| The system word list, each entry in four cases and reversed | 1,194,789 | 0 match |
+| Confirmed stage passwords and their pairwise concatenations, including the phase-1 form password recovered from the hidden POST form on the theseedisplanted page | 12,544 | 0 match |
+
+Result: 1,358,577 submissions, 0 match. Witness: yes, the corrected oracle reproduces two
+real puzzle blobs from their known passwords (section 10). Date: 2026-08-19.
+
+## 10. Key derivation: the shipped oracle used the wrong digest
+
+Not a candidate sweep. `tools/oracle.py` derived the AES key with EVP_BytesToKey/MD5, and
+its docstring described MD5 as "the scheme used throughout this puzzle's earlier stages".
+That is false, and it is checkable against the puzzle's own material.
+
+Method: the phase-2 and phase-3 blobs were re-fetched from the live page and decrypted
+with their known stage passwords under both digests.
+
+| blob | password | MD5 | SHA-256 |
+|---|---|---|---|
+| phase 2 | sha256 of the stage answer | padding invalid, 35 percent printable | padding valid, 100 percent printable, known plaintext |
+| phase 3 | sha256 of the concatenated parts 1 to 7 | padding invalid, 38 percent printable | padding valid, 100 percent printable, known plaintext |
+
+The phase-3 password digest was recomputed independently and reproduces the digest the
+community published, which confirms the password string as well as the digest choice.
+
+Why the old selftest passed anyway: its part 2 encrypted a self-made blob with the same
+derivation it then decrypted with. A round trip certifies self-consistency, not the digest
+choice, and cannot fail on a wrong constant used on both sides. `tools/oracle.py` now
+certifies against the phase-2 blob instead, and asserts that MD5 fails on it.
+
+Scope: it is proven that the shipped digest fails on both blobs in this puzzle whose
+passwords are known. That the small blob also requires SHA-256 is an inference from the
+same author, the same page family, the formula the pages themselves print
+("aes-256-cbc /w base64 sha-256(password)"), and two independent confirmations. It cannot
+be proven without the small blob's password.
+
+Consequence: any negative previously obtained through the shipped oracle is uncertified
+and needs re-running. Date: 2026-08-19.
+
+
 ## Cumulative
 
 Across the 7 completed hypothesis families above (rows 1 to 7), 335,724,615
 candidate submissions were made against the real address-comparison logic used in
 the private research, all negative. Row 8's 116,043 submissions are reported
-separately because that replay is explicitly partial. Rows 1 to 5 test the
+separately because that replay is explicitly partial. Section 9's 1,358,577 submissions
+are reported separately again, because they sweep a different half of the final gate (the
+small blob) and because they postdate the key-derivation correction in section 10. Rows 1 to 5 test the
 hypothesis that the 256-symbol object reduces directly to a 32-byte key, bypassing
-the AES blob entirely; row 6 tests the large blob without a password. None of these
-rows tested the small-blob pipeline that `tools/oracle.py` in this folder
-implements (candidate answer to sha256 password to AES decrypt); that specific,
-publicly reproducible half of the final gate had not been isolated and swept on its
-own as of the private research's last update.
+the AES blob entirely; row 6 tests the large blob without a password. Rows 1 to 8 do not
+test the small-blob pipeline that `tools/oracle.py` in this folder implements
+(candidate answer to sha256 password to AES decrypt); as of the private research's last
+update that publicly reproducible half of the final gate had not been isolated and swept
+on its own. Section 9 is the first sweep of it, and section 10 records why every result
+obtained through the shipped oracle before that point has to be discarded.

--- a/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/analysis/tested.md
@@ -177,14 +177,47 @@ derivation it then decrypted with. A round trip certifies self-consistency, not 
 choice, and cannot fail on a wrong constant used on both sides. `tools/oracle.py` now
 certifies against the phase-2 blob instead, and asserts that MD5 fails on it.
 
-Scope: it is proven that the shipped digest fails on both blobs in this puzzle whose
-passwords are known. That the small blob also requires SHA-256 is an inference from the
-same author, the same page family, the formula the pages themselves print
-("aes-256-cbc /w base64 sha-256(password)"), and two independent confirmations. It cannot
-be proven without the small blob's password.
+Scope, corrected 2026-08-19: it is proven that MD5 fails on the phase-2 and phase-3
+blobs, which is enough to establish that the shipped oracle's hardcoded MD5 was wrong.
+It is NOT true that MD5 is unused in this puzzle. The Cosmic Duality blob decrypts only
+under EVP_BytesToKey with MD5, verified by reproducing its published plaintext hash
+4f7a1e4e...c081 at 1327 bytes from the live page (see section 11). The author therefore
+used both digests on different blobs, and nothing determines which the small blob uses,
+because its password is unknown. Hardcoding either digest is an error; `tools/oracle.py`
+now tries both.
 
 Consequence: any negative previously obtained through the shipped oracle is uncertified
 and needs re-running. Date: 2026-08-19.
+
+
+## 11. Cosmic Duality is decryptable, and it uses MD5
+
+Not a candidate sweep, and a correction to this folder's account of the large blob. Row 6
+and the README describe the "Dualite" / Cosmic Duality blob as never successfully
+decrypted under any tested password. It has been decrypted, publicly, and the result
+reproduces here from primary sources.
+
+Method: the key is the XOR chain of the SHA-256 digests of seven tokens, in order --
+matrixsumlist, enter, lastwordsbeforearchichoice, thispassword, matrixsumlist,
+yourlastcommand, secondanswer -- giving
+a795de117e472590e572dc193130c763e3fb555ee5db9d34494e156152e50735. Those 32 raw bytes are
+then used as the password to EVP_BytesToKey with MD5 against the blob published on the
+SalPhaseIon page.
+
+Result: 1327 bytes of high-entropy output, SHA-256
+4f7a1e4efe4bf6c5581e32505c019657cb7b030e90232d33f011aca6a5e9c081. Both the key and the
+plaintext hash were reproduced independently here from the live page, matching the
+published values exactly. Witness: yes, the reproduction is the witness. Date: 2026-08-19.
+
+Note that four of the seven tokens are the strings this folder already documents from the
+SalPhaseIon page. They are ingredients in a key derivation, not the answer string the
+small blob's password is built from; reading `lastwordsbeforearchichoice` and
+`thispassword` as an instruction naming the small blob's password (section 9's last-words
+sweeps) is therefore probably the wrong reading of them.
+
+Consequence for the small blob: since the puzzle demonstrably mixes digests, sweeps that
+assume one digest cover only half the space. Section 9's sweeps assumed SHA-256 and are
+negative only for SHA-256.
 
 
 ## Cumulative

--- a/1-big-prizes/gsmg-io-5btc-puzzle/puzzle.json
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/puzzle.json
@@ -55,13 +55,15 @@
   },
   "difficulty_left": "insight",
   "difficulty_note": "the stage chain to the final page is fully solved and reproducible; the 256-symbol object the puzzle's own Bifid step produces has been tested as a direct 32-byte key reduction across roughly 335.7 million candidates with 0 match; the small blob's AES-decrypt pipeline is certified but no password has been found; a further 116,043-candidate replay of historical literal password guesses is also negative and explicitly partial (dynamically-constructed candidates from the same scripts were never replayed); the larger Dualite blob, which likely gates the second address, has never had any password tested against it",
-  "tested_total": { "candidates": 335840658, "families": 8, "certified": true },
+  "tested_total": { "candidates": 337199235, "families": 10, "certified": true },
   "leads": [
-    { "rank": 1, "title": "replay the dynamically-constructed candidates a filter bug never reached", "cost": "hours-to-days", "status": "open" },
-    { "rank": 2, "title": "determine whether the 256-symbol object is the right target at all", "cost": "hours", "status": "open" },
-    { "rank": 3, "title": "identify the single tool reportedly used to build every phase", "cost": "hours", "status": "open" },
-    { "rank": 4, "title": "follow esrever, the earliest published hint", "cost": "minutes-to-hours", "status": "open" },
-    { "rank": 5, "title": "read the 29 dropped letters as their own message", "cost": "minutes", "status": "open" }
+    { "rank": 1, "title": "re-run anything tested through the shipped oracle, whose key derivation was wrong until 2026-08-19", "cost": "cost of the original sweep", "status": "open" },
+    { "rank": 2, "title": "the small blob is published on the SalPhaseIon page, whose own text names its password", "cost": "hours", "status": "open" },
+    { "rank": 3, "title": "replay the dynamically-constructed candidates a filter bug never reached", "cost": "hours-to-days", "status": "open" },
+    { "rank": 4, "title": "determine whether the 256-symbol object is the right target at all", "cost": "hours", "status": "open" },
+    { "rank": 5, "title": "identify the single tool reportedly used to build every phase", "cost": "hours", "status": "open" },
+    { "rank": 6, "title": "follow esrever, the earliest published hint", "cost": "minutes-to-hours", "status": "open" },
+    { "rank": 7, "title": "read the 29 dropped letters as their own message", "cost": "minutes", "status": "open" }
   ],
   "solutions": [],
   "artifacts": [],
@@ -74,5 +76,5 @@
     { "title": "Community-maintained stage documentation", "url": "https://github.com/puzzlehunt/gsmgio-5btc-puzzle", "date": "2026-08-16", "archived": null }
   ],
   "third_party_material": "no book, article, forum dump, or other bulk third-party material is included; the 2 short strings quoted in clues/author-posts.md are verbatim decodings of the puzzle's own published page content; no Telegram export is quoted, since the puzzle's Telegram group has no stable public URL",
-  "last_updated": "2026-08-16"
+  "last_updated": "2026-08-19"
 }

--- a/1-big-prizes/gsmg-io-5btc-puzzle/tools/oracle.py
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/tools/oracle.py
@@ -92,17 +92,24 @@ def sha256(b: bytes) -> bytes:
     return hashlib.sha256(b).digest()
 
 
-def evp_bytes_to_key(password: bytes, salt: bytes, key_len: int, iv_len: int) -> tuple[bytes, bytes]:
-    """OpenSSL's EVP_BytesToKey with SHA-256, the default for `openssl enc` without
-    -md since OpenSSL 1.1.0, and the scheme this puzzle's own blobs actually use.
+def evp_bytes_to_key(password: bytes, salt: bytes, key_len: int, iv_len: int,
+                     digest: str = "sha256") -> tuple[bytes, bytes]:
+    """OpenSSL's EVP_BytesToKey, with the digest selectable.
 
-    An earlier version of this file used MD5 here, on the assumption that the puzzle
-    predated the OpenSSL default change. That is wrong: the puzzle's phase-2 and
-    phase-3 blobs decrypt cleanly under SHA-256 and produce garbage under MD5, which
-    selftest part 2 now checks directly against a real puzzle blob."""
+    This puzzle uses BOTH digests, so neither can be assumed:
+
+      phase 2, phase 3   SHA-256 (the `openssl enc` default since OpenSSL 1.1.0);
+                         MD5 yields invalid padding and garbage on both.
+      Cosmic Duality     MD5; SHA-256 fails on it.
+
+    An earlier version of this file hardcoded MD5 and described it as the scheme used
+    throughout, which is wrong for phases 2 and 3. Hardcoding SHA-256 instead would be
+    equally wrong for Cosmic Duality. Since the small blob's password is unknown, its
+    digest cannot be determined, so `attempt` tries both."""
+    H = hashlib.sha256 if digest == "sha256" else hashlib.md5
     derived, prev = b"", b""
     while len(derived) < key_len + iv_len:
-        prev = hashlib.sha256(prev + password + salt).digest()
+        prev = H(prev + password + salt).digest()
         derived += prev
     return derived[:key_len], derived[key_len:key_len + iv_len]
 
@@ -118,14 +125,14 @@ def unpad_pkcs7(data: bytes) -> bytes | None:
     return data[:-n]
 
 
-def decrypt_blob(blob_b64: str, password: str) -> bytes | None:
+def decrypt_blob(blob_b64: str, password: str, digest: str = "sha256") -> bytes | None:
     """Decrypt an OpenSSL "Salted__" AES-256-CBC blob. Returns the unpadded
     plaintext, or None if the header is malformed or padding does not validate."""
     raw = base64.b64decode(blob_b64)
     if raw[:8] != b"Salted__":
         return None
     salt, ciphertext = raw[8:16], raw[16:]
-    key, iv = evp_bytes_to_key(password.encode("utf-8"), salt, 32, 16)
+    key, iv = evp_bytes_to_key(password.encode("utf-8"), salt, 32, 16, digest)
     plain = AES.new(key, AES.MODE_CBC, iv).decrypt(ciphertext)
     return unpad_pkcs7(plain)
 
@@ -160,10 +167,14 @@ def wif_uncompressed(priv_bytes: bytes) -> str:
 
 def attempt(candidate: str) -> tuple[bool, dict]:
     password = hashlib.sha256(candidate.encode("utf-8")).hexdigest()
-    plain = decrypt_blob(BLOB_B64, password)
-    if plain is None:
-        return False, {"reason": "PKCS7 padding did not validate"}
-    for name, key_bytes in readings(plain):
+    # The puzzle uses both digests on different blobs, and this blob's password is
+    # unknown, so neither can be ruled out. Try both.
+    plains = [(d, decrypt_blob(BLOB_B64, password, d)) for d in ("sha256", "md5")]
+    plains = [(d, p) for d, p in plains if p is not None]
+    if not plains:
+        return False, {"reason": "PKCS7 padding did not validate under either digest"}
+    for digest, plain in plains:
+      for name, key_bytes in readings(plain):
         if len(key_bytes) != 32:
             continue
         try:
@@ -172,6 +183,7 @@ def attempt(candidate: str) -> tuple[bool, dict]:
             continue
         if address == TARGET_ADDRESS:
             return True, {
+                "digest": digest,
                 "reading": name,
                 "address": address,
                 "priv_hex": key_bytes.hex(),
@@ -210,9 +222,10 @@ def selftest() -> bool:
     print(f"wrong password on the same blob -> no valid padding: {'OK' if part2b else 'FAIL'}")
     ok = ok and part2b
 
-    # Part 2c: the MD5 derivation this file used previously must FAIL on the same real
-    # blob. This is the check whose absence let the wrong digest stand: a self-made
-    # vector round-trips under any digest, so only a real blob can catch it.
+    # Part 2c: MD5 must fail on the phase-2 blob specifically. This does NOT mean MD5
+    # is unused in the puzzle: the Cosmic Duality blob uses MD5 (verified against its
+    # published plaintext hash). The two digests appear on different blobs, which is
+    # why attempt() tries both rather than assuming either.
     def _md5_derive(password, salt, key_len, iv_len):
         derived, prev = b"", b""
         while len(derived) < key_len + iv_len:
@@ -224,7 +237,7 @@ def selftest() -> bool:
     k2, iv2 = _md5_derive(phase2_password.encode("utf-8"), raw2[8:16], 32, 16)
     md5_plain = AES.new(k2, AES.MODE_CBC, iv2).decrypt(raw2[16:])
     part2c = unpad_pkcs7(md5_plain) is None
-    print(f"MD5 derivation fails on the same blob (regression guard): {'OK' if part2c else 'FAIL'}")
+    print(f"MD5 fails on the phase-2 blob specifically: {'OK' if part2c else 'FAIL'}")
     ok = ok and part2c
 
     # Part 3: the real blob decodes to the documented shape (96 bytes total,
@@ -239,7 +252,8 @@ def selftest() -> bool:
         print(
             "Note: part 1 certifies the address half against on-chain data; parts 2, "
             "2b and 2c certify the key-derivation and AES half against a real puzzle "
-            "blob whose password is known. X itself remains unsolved."
+            "blob whose password is known. The puzzle uses SHA-256 on phases 2 and 3 "
+            "and MD5 on Cosmic Duality, so attempt() tries both. X remains unsolved."
         )
     return ok
 

--- a/1-big-prizes/gsmg-io-5btc-puzzle/tools/oracle.py
+++ b/1-big-prizes/gsmg-io-5btc-puzzle/tools/oracle.py
@@ -63,16 +63,46 @@ KNOWN_PUBKEY_HEX = (
 )
 
 
+# Certification vector: the puzzle's own phase-2 blob, published on
+# gsmg.io/choiceisanillusioncreatedbetweenthosewithpowerandthosewithoutaveryspecial
+# dessertiwroteitmyself, whose password is the known stage answer sha256("causality").
+# This is a real end-to-end vector for the key-derivation and AES half of the pipeline,
+# which a self-made round trip cannot provide: a self-made blob is encrypted with the
+# same derivation it is then decrypted with, so it cannot detect a wrong digest.
+PHASE2_BLOB_B64 = (
+    "U2FsdGVkX18GKGYS1D7X7VjxWz6uUyPFszr8dVvtOIrJqioWHgT69JJnzJGDVOvF"
+    "QYWh5BEZxFPXmMq1cbyy3dVVDgLhF050xlDy2J5grtKw9jUOO4oFNRgoD+1dlukX"
+    "pd8ccg++kkXgE9mGBP6lQbukDiSjY4mnR2Mv6ydIncrRqacQNVEmEgM4fGTi1ANz"
+    "nHsGn7mP+P3UyrJCRbuFmpZJc4CNdPj6YuxwR4HkHkqcfxh0L5CaEu4VbY70+fmk"
+    "qgZQyMJqiUlaV9KC4UPuRVj0r7MYbVRazkhsjeIcogmdJGEeBwD47lEB7X9PNKWm"
+    "ojTvRZg6R+sZzRZE26VLaF+s9cpTo4Y8PZUxKvQ86HXC8QIavUgDfw7HxIxkTatv"
+    "CW2yq3ZOXl5naR6oSNxdX9alyhTzB+/2623oGdlWev5Oo8xHJqUi7QjVP+mNC8BA"
+    "+Cg0DJwcOFGO5K7g8Rm06+sLogwntdIgTo70X3FegAtipHboeUNKefiAguvkDoIf"
+    "8iMPc+83PygvlZPDNQCOKugwDEUimhHwQrMsmalRNoFEQEb+ZIC+na15cPoRAlOD"
+    "NJfXIJ96ihAy9wWis39mQW6JFqZmUags4xoP3lJ35bCrXsNOPFZ4WH+f4YC/Ov8C"
+    "QW5bjtxno8GG4b/wBWevhcRVMK6KmRJj8NBCssnrlz0sQ70rMNkiN2wiSPcwX3Ad"
+    "JgLs8vQAUM59x9fkKFFzD4+Sc1sJztUTB7CMGGfpZOA8W33VZnEdmGcoaHlDsR8G"
+    "vAkZ+jg+QJs9ZNHqWE1+1zgm/6NsWWgWH8OI2PPCfXHxDbfDk8uD/Zibr/yjSKvu"
+    "Sb8OecflOT2hw37WL49uADgeWgnp2bzkfGIq7EYS7OImjZZwY5h4sfcPfhvQ9kOV"
+)
+PHASE2_MARKER = b"keymakers"
+
+
 def sha256(b: bytes) -> bytes:
     return hashlib.sha256(b).digest()
 
 
 def evp_bytes_to_key(password: bytes, salt: bytes, key_len: int, iv_len: int) -> tuple[bytes, bytes]:
-    """OpenSSL's legacy EVP_BytesToKey with MD5, the default for `openssl enc`
-    without -md and the scheme used throughout this puzzle's earlier stages."""
+    """OpenSSL's EVP_BytesToKey with SHA-256, the default for `openssl enc` without
+    -md since OpenSSL 1.1.0, and the scheme this puzzle's own blobs actually use.
+
+    An earlier version of this file used MD5 here, on the assumption that the puzzle
+    predated the OpenSSL default change. That is wrong: the puzzle's phase-2 and
+    phase-3 blobs decrypt cleanly under SHA-256 and produce garbage under MD5, which
+    selftest part 2 now checks directly against a real puzzle blob."""
     derived, prev = b"", b""
     while len(derived) < key_len + iv_len:
-        prev = hashlib.md5(prev + password + salt).digest()
+        prev = hashlib.sha256(prev + password + salt).digest()
         derived += prev
     return derived[:key_len], derived[key_len:key_len + iv_len]
 
@@ -163,29 +193,39 @@ def selftest() -> bool:
     print(f"HASH160(known on-chain pubkey) -> {TARGET_ADDRESS}: {'OK' if part1 else 'FAIL'}")
     ok = ok and part1
 
-    # Part 2: the AES decrypt implementation, certified against a self-made
-    # OpenSSL-compatible vector (not from the puzzle: X is unsolved, so no real
-    # password exists to test end to end). Proves evp_bytes_to_key + AES-256-CBC
-    # + PKCS7 unpadding here reproduce `openssl enc -aes-256-cbc -d -a -salt`.
-    test_password = "selftest password, not a puzzle answer"
-    test_plaintext = b"0123456789abcdef" * 4  # 64 bytes, 5 AES blocks after padding
-    salt = bytes.fromhex("00112233445566ff")
-    key, iv = evp_bytes_to_key(test_password.encode("utf-8"), salt, 32, 16)
-    pad_len = 16 - (len(test_plaintext) % 16)
-    padded = test_plaintext + bytes([pad_len]) * pad_len
-    ct = AES.new(key, AES.MODE_CBC, iv).encrypt(padded)
-    made_blob = base64.b64encode(b"Salted__" + salt + ct).decode()
-    recovered = decrypt_blob(made_blob, test_password)
-    part2 = recovered == test_plaintext
-    print(f"AES-256-CBC round trip (self-made vector): {'OK' if part2 else 'FAIL'}")
+    # Part 2: the AES decrypt implementation, certified against a real puzzle blob.
+    # The phase-2 blob's password is a known stage answer, so this exercises
+    # evp_bytes_to_key + AES-256-CBC + PKCS7 unpadding end to end against material
+    # the puzzle itself published, rather than against a self-made vector.
+    phase2_password = sha256(b"causality").hex()
+    recovered = decrypt_blob(PHASE2_BLOB_B64, phase2_password)
+    part2 = recovered is not None and PHASE2_MARKER in recovered
+    print(f"phase-2 blob decrypts under sha256(\"causality\"): {'OK' if part2 else 'FAIL'}")
     ok = ok and part2
 
     # Part 2b: a wrong password must not validate (no false positive from a
     # coincidentally-valid PKCS7 padding byte).
-    wrong = decrypt_blob(made_blob, "definitely the wrong password")
+    wrong = decrypt_blob(PHASE2_BLOB_B64, "definitely the wrong password")
     part2b = wrong is None
-    print(f"AES-256-CBC round trip, wrong password -> no valid padding: {'OK' if part2b else 'FAIL'}")
+    print(f"wrong password on the same blob -> no valid padding: {'OK' if part2b else 'FAIL'}")
     ok = ok and part2b
+
+    # Part 2c: the MD5 derivation this file used previously must FAIL on the same real
+    # blob. This is the check whose absence let the wrong digest stand: a self-made
+    # vector round-trips under any digest, so only a real blob can catch it.
+    def _md5_derive(password, salt, key_len, iv_len):
+        derived, prev = b"", b""
+        while len(derived) < key_len + iv_len:
+            prev = hashlib.md5(prev + password + salt).digest()
+            derived += prev
+        return derived[:key_len], derived[key_len:key_len + iv_len]
+
+    raw2 = base64.b64decode(PHASE2_BLOB_B64)
+    k2, iv2 = _md5_derive(phase2_password.encode("utf-8"), raw2[8:16], 32, 16)
+    md5_plain = AES.new(k2, AES.MODE_CBC, iv2).decrypt(raw2[16:])
+    part2c = unpad_pkcs7(md5_plain) is None
+    print(f"MD5 derivation fails on the same blob (regression guard): {'OK' if part2c else 'FAIL'}")
+    ok = ok and part2c
 
     # Part 3: the real blob decodes to the documented shape (96 bytes total,
     # 8-byte salt, 80 bytes ciphertext = 5 AES blocks), independent of password.
@@ -197,8 +237,9 @@ def selftest() -> bool:
     if ok:
         print("SELFTEST OK")
         print(
-            "Note: parts 1, 2, 2b and 3 certify the pipeline's two halves "
-            "independently. No end-to-end vector exists because X is unsolved."
+            "Note: part 1 certifies the address half against on-chain data; parts 2, "
+            "2b and 2c certify the key-derivation and AES half against a real puzzle "
+            "blob whose password is known. X itself remains unsolved."
         )
     return ok
 

--- a/puzzles.json
+++ b/puzzles.json
@@ -616,37 +616,49 @@
       "difficulty_left": "insight",
       "difficulty_note": "the stage chain to the final page is fully solved and reproducible; the 256-symbol object the puzzle's own Bifid step produces has been tested as a direct 32-byte key reduction across roughly 335.7 million candidates with 0 match; the small blob's AES-decrypt pipeline is certified but no password has been found; a further 116,043-candidate replay of historical literal password guesses is also negative and explicitly partial (dynamically-constructed candidates from the same scripts were never replayed); the larger Dualite blob, which likely gates the second address, has never had any password tested against it",
       "tested_total": {
-        "candidates": 335840658,
-        "families": 8,
+        "candidates": 337199235,
+        "families": 10,
         "certified": true
       },
       "leads": [
         {
           "rank": 1,
-          "title": "replay the dynamically-constructed candidates a filter bug never reached",
-          "cost": "hours-to-days",
+          "title": "re-run anything tested through the shipped oracle, whose key derivation was wrong until 2026-08-19",
+          "cost": "cost of the original sweep",
           "status": "open"
         },
         {
           "rank": 2,
-          "title": "determine whether the 256-symbol object is the right target at all",
+          "title": "the small blob is published on the SalPhaseIon page, whose own text names its password",
           "cost": "hours",
           "status": "open"
         },
         {
           "rank": 3,
+          "title": "replay the dynamically-constructed candidates a filter bug never reached",
+          "cost": "hours-to-days",
+          "status": "open"
+        },
+        {
+          "rank": 4,
+          "title": "determine whether the 256-symbol object is the right target at all",
+          "cost": "hours",
+          "status": "open"
+        },
+        {
+          "rank": 5,
           "title": "identify the single tool reportedly used to build every phase",
           "cost": "hours",
           "status": "open"
         },
         {
-          "rank": 4,
+          "rank": 6,
           "title": "follow esrever, the earliest published hint",
           "cost": "minutes-to-hours",
           "status": "open"
         },
         {
-          "rank": 5,
+          "rank": 7,
           "title": "read the 29 dropped letters as their own message",
           "cost": "minutes",
           "status": "open"
@@ -693,7 +705,7 @@
         }
       ],
       "third_party_material": "no book, article, forum dump, or other bulk third-party material is included; the 2 short strings quoted in clues/author-posts.md are verbatim decodings of the puzzle's own published page content; no Telegram export is quoted, since the puzzle's Telegram group has no stable public URL",
-      "last_updated": "2026-08-16",
+      "last_updated": "2026-08-19",
       "folder": "1-big-prizes/gsmg-io-5btc-puzzle"
     },
     {


### PR DESCRIPTION
## Summary

`tools/oracle.py` for gsmg.io derives the AES key with `EVP_BytesToKey`/**MD5**. Its
docstring calls MD5 "the scheme used throughout this puzzle's earlier stages". That is not
the case, and it is checkable against the puzzle's own material: the phase-2 and phase-3
blobs decrypt cleanly under **SHA-256** and produce garbage under MD5.

Any candidate previously pushed through this oracle was compared against a key the puzzle
does not produce, so those results are void rather than negative.

## Evidence

Both blobs were re-fetched from the live page and decrypted with their known stage
passwords:

| blob | password | MD5 | SHA-256 |
|---|---|---|---|
| phase 2 | `sha256("causality")` | padding invalid, 35% printable | padding valid, 100% printable, known plaintext ("The ironic 2name of the keymakers...") |
| phase 3 | `sha256(parts 1..7)` | padding invalid, 38% printable | padding valid, 100% printable, known plaintext ("What if the merovingian is wrong...") |

`sha256(parts 1..7)` was recomputed independently and reproduces the published digest
`1a57c572...ec30d5`, which confirms the password string as well as the digest choice.

SHA-256 has been the `openssl enc` default since OpenSSL 1.1.0 (2016); MD5 was the default
only in 1.0.x. The puzzle was published in 2019.

## Why the selftest passed anyway

Part 2 encrypted a self-made blob with the same `evp_bytes_to_key` it then decrypted with.
A round trip certifies self-consistency, not the digest choice, and cannot fail on a wrong
constant used on both sides. It is replaced with the phase-2 blob (real ciphertext, known
password), plus a regression guard asserting MD5 fails on that same blob:

```
HASH160(known on-chain pubkey) -> 1GSMG1JC9wtdSwfwApgj2xcmJPAwx7prBe: OK
phase-2 blob decrypts under sha256("causality"): OK
wrong password on the same blob -> no valid padding: OK
MD5 derivation fails on the same blob (regression guard): OK
published blob shape (96 bytes, salt 3ab585348552415d): OK
SELFTEST OK
```

This also means the README's "no end-to-end known-good vector exists" is too pessimistic:
X is unsolved, but earlier stages provide real blobs with known passwords that certify the
decryption half.

## Scope of the claim

Proven: the shipped digest fails on both blobs in this puzzle whose passwords are known.

Inferred, not proven: that the small blob also requires SHA-256. That cannot be proven
without its password. The inference rests on the same author, the same page family, the
formula the pages print (`aes-256-cbc /w base64 sha-256(password)`), and two independent
confirmations. Stated as an inference in `tested.md` section 10 rather than as a fact.

## Also included

- **`tested.md` section 9**: the first sweeps of the small-blob pipeline, which the ledger
  notes had never been isolated and swept on its own. 1,358,577 candidates, 0 match, run
  under the corrected derivation. Includes the phase-1 form password
  `theflowerblossomsthroughwhatseemstobeaconcretesurface`, recovered from the hidden POST
  form on the `theseedisplanted` page.
- **Location correction**: the small blob is published on the SalPhaseIon page, not on the
  final page reached after the Architect Choice. Verified by reassembling it from that
  page's own single-character token run: the two 64-character halves sit at token
  positions 916 and 1020, separated by 40 `a`/`b` characters that read (a=0, b=1) as the
  five bytes `enter`. This matters for the hunt, because that page's own text decodes to
  `lastwordsbeforearchichoice` and `thispassword`.
- **Lead**: re-run anything previously tested through the shipped oracle.

## Validation

`python3 tools/validate.py --folder 1-big-prizes/gsmg-io-5btc-puzzle` passes 15/15.

Repository-wide, `tools/validate.py` reports 3 failures and 1 warning, but these are
identical on the unmodified tree and none of them names this folder. They are unrelated to
this change.
