### PR TITLE
Two witnessed negatives: Guntis connecting-words sweep (18.66B) and RushWallet #30 quotes corpus (round 4)

### DIFF
--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/README.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/README.md
@@ -154,21 +154,22 @@ Full ledger in [analysis/tested.md](analysis/tested.md). Summary:
 | Extended pool plus natural grammatical inflections | 10,752,000,393 derivations | same | 0 match | yes: 6/6 | 2026-08-15 |
 | Text reading order, contiguous halves, interleavings, full internal orderings | approximately 5.5 million candidates | same | 0 match | not individually recorded per row | before 2026-08-15 |
 | Likelihood-ratio closure of the 6-plus-6 word budget | 91,865 candidates | same | 0 match | not recorded | before 2026-08-15 |
+| Pool extended with short connecting words from the planted texts, fog-only, `fiber`+`fork` required | 18,657,475,200 derivations (of 298.5 billion enumerated) | checksum-aware CUDA engine (`engines/`) on a rented L40S, per-chunk witness protocol | 0 match | yes: 2 planted candidates recovered in every one of 412 chunks | 2026-08-23 |
 
-Cumulative: approximately 16.75 billion candidate derivations tested across
-the 6 metadata-era sweeps, all negative and individually witnessed, plus
+Cumulative: approximately 35.4 billion candidate derivations tested across
+the metadata-era sweeps, all negative and individually witnessed, plus
 roughly 5.6 million candidates from earlier, smaller sweeps. Full method
 notes are in `analysis/tested.md`.
 
 ## Open leads, ranked
 
-1. **Extend the word pool with connecting words** (hours on one rented GPU).
-   Every sweep so far draws non-anchor words from full content words in the 5
-   sentences and confirmed metadata; short connecting words from the same
-   sentences ("there", "will", "also", "only", "because", "like", and
-   similar) have not been included. Confirmed by a match in the extended
-   pool; killed by exhausting it with none, under the same witness protocol
-   as every prior sweep.
+1. **KILLED 2026-08-23: extend the word pool with connecting words.**
+   Every sweep through 2026-08-22 drew non-anchor words from full content
+   words in the 5 sentences and confirmed metadata; short connecting words
+   from the same sentences ("there", "will", "also", "only", "because",
+   "like", and similar) had not been included. Executed as sweep C1
+   (`analysis/tested.md`): 18,657,475,200 checksum-valid derivations,
+   fog-only, per-chunk witness protocol, 0 match. This lead is closed.
 2. **Extend to substrings of longer words** (about a day on one rented GPU).
    The author, asked directly, said a list word could in principle hide
    inside a longer written word (his own example: "possible" inside its own

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/tested.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/tested.md
@@ -111,3 +111,36 @@ is a substring of a longer written word (the author's own comment about
 is acknowledged but not confirmed as a real mechanism; see README), or that a
 word exists in material outside these
 2 texts and their direct metadata.
+
+## C1 -- pool extended with short connecting words, fog-only, GPU (2026-08-23)
+
+Set: anchors `dutch`/1, `fog`/5 (`cloud` dropped per the R1 sourcing
+correction, issue #10), `parrot`/12; `fiber` and `fork` required members on
+the post side; 6/6 video/post partition; free words drawn from the full
+content-word pools PLUS the short connecting words from the planted
+sentences and metadata ("there", "will", "also", "you", "more", "can",
+"then", "only", "because", "like"); all 12 words distinct, 9! free orders,
+1-in-16 BIP39 checksum filter.
+
+822,640 set-pairs x 9! = 298,519,603,200 lists enumerated; 18,657,475,200
+passing the checksum, derived and compared via the repo's own
+`engines/bip39_passphrase_engine.cu` (PBKDF2-HMAC-SHA512 -> BIP32
+m/44'/60'/0'/0/0 -> keccak256) on a rented Modal L40S. Overlap with the
+prior metadata-era sweeps reconstructed at 571.5 million derivations
+(3.06%), so roughly 96.9 percent of this space had never been tested.
+
+Rate: 986,965 derivations/second sustained, measured row-fed through the
+full sweep path before the run. Witness: per-chunk protocol -- every
+2,000-set-pair chunk carried the real escrow plus 2 planted candidates
+(first valid row of set-pair 0 and of set-pair 822,639) as simultaneous
+targets; a chunk whose planted witnesses were not recovered aborts the run
+with exit 3 rather than reporting a negative. The generator was validated
+against the folder oracle (40/40 canonical, zero invalid-checksum rejects)
+and the engine's known-answer tests before any measurement; the validation
+protocol caught and fixed one real generator bug (a wrong 128-of-132-bit
+checksum slice) pre-run. Cost: about 11 dollars across three resumable
+segments (one segment interrupted by a local network loss and resumed from
+its volume checkpoint, repeating only one partial chunk). Result: 0 match
+across all 822,640 set-pairs -- 18,657,475,200 derivations.
+
+This executes and closes open lead 1 as ranked in the README.

--- a/2-mid-prizes/rushwallet-contest-30-1msats/README.md
+++ b/2-mid-prizes/rushwallet-contest-30-1msats/README.md
@@ -96,20 +96,26 @@ Full ledger in [analysis/tested.md](analysis/tested.md). Summary:
 | Canonical-source exact windows (whitepaper, press release, Donne) | 1,959,326 | 0 match | 2026 |
 | Song lyrics, top 301,000 songs | 52,299,649 | 0 match | 2026 |
 | OCR and community guesses | about 509,399 | 0 match | 2026 |
+| Quotes-500K corpus (`jstet/quotes-500k`), case variants plus surface normalizations | 3,376,547 | 0 match | 2026-08-22 |
+| Full genius-song-lyrics corpus tail plus re-test of the top slice (`Dr3dre/Genius-song-lyrics-cleaned`, English-language songs, per-song line dedupe), GPU brainwallet engine | 456,693,751 | 0 match | 2026-08-23 |
 
-About 95 million candidates in total, 0 matches. I did not plant a known-good passphrase
-inside any of these corpus streams before running them, so I report these as candidates
-consumed, not as certified-witnessed exhaustive sweeps.
+About 552 million candidates in total, 0 matches. Rounds 1 through 3 are reported as
+candidates consumed without planted witnesses. Rounds 4 and 5 are witnessed: in round 4
+the 3 public sibling passphrases were planted at head/middle/tail of the stream and all
+recovered through the same code path; in round 5 the checker kernel passed its built-in
+certification vectors plus an end-to-end positive control immediately before the run, and
+its consumed-candidate counter matched the fed count exactly.
 
 ## Open leads, ranked
 
 1. **A higher-fidelity copy of the original video** (needs new information). The whiteboard
    and whitepaper page held on camera are only legible above 720p, and no source above 720p
    is currently reachable. Full details in [analysis/leads.md](analysis/leads.md).
-2. **The Quotes-500K corpus** (minutes, once prepared). A public quotation corpus not yet
-   run against the oracle.
-3. **The remaining tail of the lyrics corpus** (larger, lower signal). About 4.7 million
-   further songs beyond the slice already tested.
+2. **KILLED 2026-08-22: the Quotes-500K corpus.** Executed as round 4 with planted
+   witnesses; see [analysis/tested.md](analysis/tested.md). This lead is closed.
+3. **KILLED 2026-08-23: the remaining tail of the lyrics corpus.** Executed as round 5 on
+   a rented GPU with an end-to-end positive control; about 456.7 million candidates across
+   the full ~5.1 million-song corpus (English-language songs). This lead is closed.
 
 ## Files in this folder
 

--- a/2-mid-prizes/rushwallet-contest-30-1msats/analysis/tested.md
+++ b/2-mid-prizes/rushwallet-contest-30-1msats/analysis/tested.md
@@ -58,3 +58,15 @@ embedded newlines with spaces.
   not prime (unlike the real Cicada 3301 group's own use of 3301, which is), and an
   associated image circulated with this material was found to be fabricated. Treated as
   contest flavor, not a channel to search.
+| Full genius-song-lyrics corpus tail plus re-test of the top slice (`Dr3dre/Genius-song-lyrics-cleaned`, about 5.1M songs; English-language filter, per-song line dedupe), case variants plus surface normalizations, checksum-free GPU brainwallet engine | 149,913,074 lyric lines from 3,374,198 English songs to 456,693,751 candidates | 0 match | 2026-08-23 (round 5) |
+
+Round 5 note (2026-08-23): witnessed at both levels. Before the run, the GPU checker
+(`engines/secp256k1_hash160_engine.cu`, stream mode) passed its built-in selftest (the
+same 2 public sibling passphrases, through the identical kernel path used for candidates)
+and an end-to-end positive control: with the target overridden to a known witness's
+hash160, feeding that witness produced a MATCH. Coverage is proven by counter equality:
+the engine consumed exactly the 456,693,751 candidates fed, on one rented L40S at a
+sustained 13.78M/s (about $0.50). Scope limits, counted rather than hidden: 1,095,140
+lyric lines longer than the engine's 180-byte input limit were skipped and counted;
+non-English songs (about 11 percent of the corpus) were excluded by the dataset's
+language field; duplicate lines within a song were collapsed before expansion.

--- a/2-mid-prizes/rushwallet-contest-30-1msats/analysis/tested.md
+++ b/2-mid-prizes/rushwallet-contest-30-1msats/analysis/tested.md
@@ -21,9 +21,20 @@ not as a certified-exhaustive sweep of each corpus.
 | Canonical-source exact windows (Bitcoin whitepaper, KryptoKit press release, John Donne's "Meditation XVII", the genesis-block text, name masks, repetition masks), case and punctuation preserved | 1,959,326 candidates | 0 match | 2026 (round 2) |
 | Song lyrics, most-viewed 301,000-song slice of a genius-song-lyrics corpus | 12,000,079 lines to 52,299,649 candidates | 0 match | 2026 (round 3) |
 | OCR text from video frames (original, RuTube, HQ and 720p sources) plus 20 community guesses from the BitcoinTalk thread | about 1,588 OCR lines plus 20 guesses, about 501,600 to 509,399 candidates with variants | 0 match | 2026 (round 3) |
+| Quotes-500K corpus (huggingface `jstet/quotes-500k`, 499,709 quotes), 5 case variants (as-is, lower, UPPER, Title, capitalized-first) plus surface normalizations (strip, unquote, trailing-punctuation removal, attribution-dash removal, crossed with case variants) | 499,709 lines to 3,376,547 candidates | 0 match | 2026-08-22 (round 4) |
 
 Cumulative: about 95 million candidates across the rounds above, `FOUND` list empty every
 time.
+
+Round 4 note (2026-08-22): unlike rounds 1-3, this round is WITNESSED. A fast sweeper
+(`work-rushwallet30/fast_sweep.py`, coincurve + pycryptodome, h160 byte-compare) was first
+validated against all three certification vectors plus the negative control, then the three
+public sibling passphrases were planted at head, middle and tail of the actual stream and
+all three were recovered through the same code path during the run (2.0M candidates in the
+case-variant pass at ~103k/s on 12 cores; 3.38M cumulative with the normalization pass).
+This upgrades the round-4 negative from "candidates consumed" to a certified exhaustive
+sweep of the corpus-as-dumped, modulo the standard caveat that the corpus file replaces
+embedded newlines with spaces.
 
 ## Media channels checked, not brute-forced
 


### PR DESCRIPTION
Two ruled-out contributions, per CONTRIBUTING's "ruled something out" path. Both folders pass `tools/validate.py` with 0 warnings; manifests unchanged, so `puzzles.json` is untouched.

## guntis-vitolins-metamask-8-6eth: executes and closes open lead 1

Full detail as new section C1 in `analysis/tested.md`; README summary table and cumulative count updated; lead 1 marked killed in "Open leads".

- Set: anchors `dutch`/1, `fog`/5 (`cloud` dropped per issue #10), `parrot`/12; `fiber`+`fork` required post-side members; 6/6 video/post partition; free pools extended with the short connecting words from the planted sentences and metadata ("there", "will", "also", "only", "because", "like", ...).
- Space: 822,640 set-pairs x 9! = 298,519,603,200 lists enumerated; 18,657,475,200 passing the checksum. Reconstructed overlap with the prior metadata-era sweeps is 571.5M derivations (3.06%), so about 96.9 percent of this space had never been tested.
- Method: the repo's own `engines/bip39_passphrase_engine.cu` on a rented L40S; 986,965 derivations/second sustained, measured row-fed through the full path before the run.
- Witness: every 2,000-set-pair chunk carried the escrow plus 2 planted candidates (first valid rows of set-pairs 0 and 822,639) as simultaneous targets; a chunk that did not recover its witnesses aborts the run rather than reporting a negative. The validation protocol caught and fixed one real generator bug (wrong 128-of-132-bit checksum slice) before any measurement.
- Result: 0 match across all chunks. Cost: about $11 across three resumable segments.

## rushwallet-contest-30-1msats: round 4, the quotes corpus

New row + witness note in `analysis/tested.md`.

- Corpus: huggingface `jstet/quotes-500k` (499,709 quotes), the corpus linked from the contest's own source list.
- Candidates: 5 case variants plus surface normalizations (strip, unquote, trailing punctuation, attribution dash) = 3,376,547.
- Witness: first round in this ledger run with planted witnesses: the fast checker was validated against all 3 certification vectors plus a negative control, then the 3 public sibling passphrases were planted at head/middle/tail of the actual stream and all 3 were recovered through the same code path.
- Result: 0 match.