### PR TITLE
guntis-vitolins-metamask-8-6eth: reading-order model swept and closed, leads re-ranked, one author attribution corrected

### DIFF
--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/README.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/README.md
@@ -59,9 +59,15 @@ The blog post carries 3 more, mid-paragraph, also unrelated to its subject:
 
 That these 5 sentences are deliberately inserted, not incidental, is
 confirmed statistically: their language departs from the author's other posts
-at z = 3.71 against a control corpus of his 4 other blog entries. The text of
-both the video description and the blog post is confirmed unchanged since
-2020, checked against a 2020-05-28 web archive capture, byte for byte.
+at z = 3.71 against a control corpus of his 4 other blog entries. The 5 planted
+sentences, the video title and the post's tags are confirmed unchanged since
+2020, checked against a 2020-05-28 web archive capture. That claim is
+deliberately narrower than "both pages are unchanged byte for byte", which is
+not true: the video description's contact address was later edited from an
+"info@" form to a "guntis@" form, and its rules block accreted more text as
+each new hint was published. Those edits sit outside the planted sentences, but
+anyone diffing the live page against the archive should expect to see them and
+should not read them as tampering with the payload.
 
 Across roughly 40 of his later video descriptions, the author published 5
 hints, the last 2 of which are spoken rather than written: the final word is a
@@ -117,10 +123,17 @@ English wordlist is exactly 1 in 16, as the format requires. Reproduced
    the source texts.
 2. The last position is `parrot`: of 14 BIP39 dictionary words naming birds,
    only `parrot` is tropical, matching hint 1.
-3. Position 5 is `fog` or `cloud`: of 20 BIP39 dictionary words related to
-   water, only `fog` and `lake` appear in the source texts, and a lake is not
-   made of condensed droplets; which of the 2 remaining candidates is correct
-   is not settled.
+3. Position 5 is `fog`. Narrowing hint 3 from "related to water" to its actual
+   wording, condensed water droplets, leaves exactly 3 BIP39 dictionary words:
+   `fog`, `cloud` and `vapor`. `vapor` is the gas phase, not condensed
+   droplets, which leaves `fog` and `cloud`, and of those 2 only `fog` appears
+   in any recovered 2020 written surface, at index 25 of the video description.
+   `lake` appears there too but a lake is not made of condensed droplets. The
+   author's own reply in a comment thread, that a hint may gloss a word while
+   the challenge text carries the exact one, points the same way. Treat this as
+   settled with 1 reservation: `cloud` becomes live again if it turns out to be
+   legible in the video image, which nobody has read yet. See "Open leads,
+   ranked", lead 1.
 4. `fiber` and `fork` are confirmed list members with unconfirmed positions,
    from hints 4 and 5, each verified against both YouTube's official captions
    and an independent local transcription.
@@ -154,35 +167,65 @@ Full ledger in [analysis/tested.md](analysis/tested.md). Summary:
 | Extended pool plus natural grammatical inflections | 10,752,000,393 derivations | same | 0 match | yes: 6/6 | 2026-08-15 |
 | Text reading order, contiguous halves, interleavings, full internal orderings | approximately 5.5 million candidates | same | 0 match | not individually recorded per row | before 2026-08-15 |
 | Likelihood-ratio closure of the 6-plus-6 word budget | 91,865 candidates | same | 0 match | not recorded | before 2026-08-15 |
+| Complete reading-order model over the full recovered 2020 text and metadata, 3 anchors fixed, `fork` free | 10,484,919 derivations (of 167,688,000 arrangements, matching a closed form) | closed-form count, then checksum, then address compare | 0 match | yes: 1,062 planted and recovered, 0 disagreements between 2 engines | 2026-08-20 |
+| The same reading-order model extended to substrings of longer words | 582,725 derivations (of 9,334,500 arrangements) | same | 0 match | yes | 2026-08-20 |
 
 Cumulative: approximately 16.75 billion candidate derivations tested across
 the 6 metadata-era sweeps, all negative and individually witnessed, plus
-roughly 5.6 million candidates from earlier, smaller sweeps. Full method
-notes are in `analysis/tested.md`.
+roughly 5.6 million candidates from earlier, smaller sweeps, plus the 11.07
+million derivations of the 2 reading-order sweeps above. Full method notes are
+in `analysis/tested.md`.
+
+The reading-order sweep matters out of proportion to its size. It is the first
+sweep here whose space is stated as a closed form and then enumerated to that
+exact count, so its coverage claim is checkable. Reading order was also the
+assumption that made this challenge searchable at all: dropping it, over the
+same pool and the same 3 anchors, gives `C(38,4) * C(82,3) * 9!` =
+2.3722x10^15 arrangements and 1.4826x10^14 derivations, which is 5.9 years on 1
+GPU at 792,000 derivations/second. That assumption is now closed and negative
+over 100 percent of its space, which moves the binding constraint from search to
+word identification and re-orders the leads below.
 
 ## Open leads, ranked
 
-1. **Extend the word pool with connecting words** (hours on one rented GPU).
-   Every sweep so far draws non-anchor words from full content words in the 5
-   sentences and confirmed metadata; short connecting words from the same
-   sentences ("there", "will", "also", "only", "because", "like", and
-   similar) have not been included. Confirmed by a match in the extended
-   pool; killed by exhausting it with none, under the same witness protocol
-   as every prior sweep.
-2. **Extend to substrings of longer words** (about a day on one rented GPU).
-   The author, asked directly, said a list word could in principle hide
-   inside a longer written word (his own example: "possible" inside its own
-   negation, formed with the prefix "im-"), though this may describe the
-   existing paraphrase-hint
-   mechanism rather than a literal substring rule; it has not been tested at
-   scale under the metadata-extended pool. Confirmed by a match; killed by
-   exhaustion.
-3. **Re-read the video and post metadata once more** (about an hour, no
-   sweep). The blog post's tags were missed for years until a 2026-08-15
-   re-read found `fork` there; the video's own metadata and any remaining
-   unread HTML attributes on the post have not had the same close pass since.
-   Confirmed by a new word found and matched; has no natural exhaustion
-   point beyond a careful, complete re-read.
+1. **Read the text shown on screen in the challenge video** (about an hour, no
+   compute). The author names on-screen text as a channel in his own spoken
+   rules, at 5:22 to 5:38 of the challenge video: the words "could be you know
+   written in the video on the screen so read carefully". Every sweep in
+   `analysis/tested.md` draws its pool from the description, title, tags and
+   post body; not 1 frame of the video image has been read. The video shows a
+   portfolio table, and 10 coin names visible or audible in that segment are
+   BIP39 dictionary words (`atom`, `link`, `dash`, `cash`, `icon`, `wave`,
+   `gas`, `ocean`, `fetch`, `ripple`), none of which appears in any recovered
+   written surface. Confirmed by a legible dictionary word absent from the known
+   pool; killed by a complete frame read yielding nothing new, which unlike a
+   prose re-read is a real exhaustion point.
+2. **Extend the word pool with connecting words** (hours on 1 rented GPU).
+   Every sweep so far draws non-anchor words from full content words; short
+   connecting words from the same sentences ("there", "will", "also", "only",
+   "because", "like", and similar) have not been included. About 1.36x10^10
+   derivations. Confirmed by a match in the extended pool; killed by exhausting
+   it with none, under the same witness protocol as every prior sweep.
+3. **Re-check the already-enumerated survivors on other derivation paths**
+   (about 4 hours on 2 CPU cores, seconds on a GPU). Every sweep here derives
+   only `m/44'/60'/0'/0/0`. If the escrow is the second account of the same
+   wallet, every negative in this folder is a negative about the wrong address.
+   Re-checking `m/44'/60'/0'/0/1`, `m/44'/60'/0'/0/2`, `m/44'/60'/1'/0/0` and
+   `m/44'/60'/2'/0/0` costs about 28 percent of the original derivation work,
+   because the seed stretch is already done and only the child derivation
+   repeats. Killed by 0 match across all 4, which upgrades every existing
+   negative here from "negative at the default path" to "negative across the
+   plausible path family". Best value experiment currently available.
+4. **Substrings of longer words** (about a day on 1 rented GPU). Demoted, with
+   a correction. This lead used to credit the author with an example of a list
+   word nested inside its own negation. Reading the thread directly shows that
+   example came from the reader asking the question; the author's own example is
+   "usa" for "united states", he offers it about hints, and he adds that the
+   challenge text "wikk have corect word". So the mechanism is a reader's
+   hypothesis the author did not contradict, not an author-stated rule. All 5
+   confirmed list words are whole tokens, which is weak further evidence
+   against it. About 2.78x10^11 derivations; the reading-order corner is
+   already swept.
 
 Full notes: [analysis/leads.md](analysis/leads.md).
 
@@ -190,19 +233,22 @@ Full notes: [analysis/leads.md](analysis/leads.md).
 
 | Path | What it is |
 |---|---|
-| `clues/author-posts.md` | the 5 planted sentences, the 5 hints, and paraphrased author statements, with dates and links |
+| `clues/author-posts.md` | the 5 planted sentences, the 5 hints, the author's comment replies quoted verbatim, and his spoken statement of the channels, with dates and links |
 | `data/seed-slots.json` | the 12-position grid state, for the seed slot figure |
+| `data/reading-order-pool.json` | the derived reading-order index the sweep script consumes: which dictionary words appear in which source range, in written order |
 | `analysis/tested.md` | the complete negatives ledger |
-| `analysis/leads.md` | full notes behind the 3 ranked leads |
+| `analysis/leads.md` | full notes behind the 4 ranked leads |
 | `images/01-seed-slot-grid.svg` | the 12-word seed grid, confirmed vs unknown |
 | `tools/oracle.py` | candidate checker, certified against the canonical BIP-0039 vector |
 | `tools/fig_slots.py` | generates images/01-seed-slot-grid.svg from data/seed-slots.json |
+| `tools/sweep_reading_order.py` | the reading-order sweep of `analysis/tested.md`; `--size` prints the closed form, `--selftest` plants and recovers a witness, `--run` is resumable |
 
 ## Sources
 
 - Challenge video, YouTube, 2020-02-12: https://www.youtube.com/watch?v=w4mpiuBP_aY
 - Challenge blog post, mineshop.eu, 2020-02-12: https://mineshop.eu/2020/02/12/crypto-pumping-hardcore-research-portfolio-update-how-are-we-doing/
 - Blog post, archived (tags visible in footer), Wayback Machine, 2020-05-28: https://web.archive.org/web/20200528000000*/mineshop.eu/2020/02/12/crypto-pumping-hardcore-research-portfolio-update-how-are-we-doing/
+- Challenge video, spoken statement of the channels including on-screen text, at 5:22 to 5:38: https://www.youtube.com/watch?v=w4mpiuBP_aY
 - Hint 4 video: https://www.youtube.com/watch?v=03wXiMczCXk
 - Hint 5 video: https://www.youtube.com/watch?v=ZjBJKooVmuE
 - #GuntisVitolins, YouTube channel: https://www.youtube.com/channel/UCkYCnjVcFJDN6Cp_uP0pv_A

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/leads.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/leads.md
@@ -1,89 +1,171 @@
 # Open leads, full notes
 
 Ranked summary is in the README. This file has the reasoning behind the
-ranking. All 3 leads below are priced and specified; none has been run.
+ranking.
 
-## 1. Extend the swept word pool with connecting words (liaisons)
+## Why the ranking changed (2026-08-21)
 
-Every completed sweep (`analysis/tested.md`) draws its non-anchor words from
-full words in the 5 planted sentences and confirmed metadata (tags, title,
-hook line). None of them include short connecting words from the same
-sentences: prepositions, articles, and conjunctions such as "there", "will",
-"also", "you", "more", "can", "then" (video side) or "only", "because",
-"there", "like" (post side). These words are cheap to add: the private
-research's own P2 estimate, before the metadata extension, priced this
-addition at 15/14 words per side, 1.36x10^10 derivations, about 3.8 hours on
-one GPU. Extending the already-metadata-inclusive R1 pool the same way is a
-comparable-sized addition.
+The previous ranking put the 2 pool-extension sweeps first and re-reading the
+sources third. Sweep RO1 in `analysis/tested.md` closed the complete
+reading-order model over the full recovered 2020 text, 167,688,000
+arrangements and 10,484,919 derivations, witnessed, 0 match. That result makes
+the sweep leads look smaller than they did:
+
+```
+free ordering over the same pool and anchors
+  = C(38,4) * C(82,3) * 9!
+  = 73,815 * 88,560 * 362,880
+  = 2.3722x10^15 arrangements
+  = 1.4826x10^14 checksum-valid derivations
+  = 5.9 years at 792,000 derivations/second
+```
+
+The liaison and substring leads together are about 0.2 percent of that. They
+are still worth running, because they are hours rather than years, but they are
+no longer plausibly where the answer is hiding. The remaining 99.8 percent is
+not purchasable at any budget this challenge justifies. So the binding
+constraint is not search, it is word identification, and the first lead below
+is now a reading task rather than a sweep.
+
+## 1. Read the text shown on screen in the challenge video
+
+The author states in the spoken rules of the challenge video,
+https://www.youtube.com/watch?v=w4mpiuBP_aY at 5:22 to 5:38, that the words
+"could be you know written in the video on the screen so read carefully". The
+written rules in the hint 5 description agree, listing "description, tags,
+title, video basically could be anywhere in this video". Quoted in
+`clues/author-posts.md`.
+
+Every sweep in `analysis/tested.md` draws its pool from the description, the
+title, the tags and the post body. None has read a single frame of the video
+image. That makes on-screen text the only author-named channel that has never
+been examined at all, which is a different class of gap from an unswept corner
+of a pool that has been read.
+
+There is independent reason to expect payload there. The video shows a
+portfolio table of coin holdings. Ten coin names visible or audible in that
+segment are BIP-0039 dictionary words: `atom`, `link`, `dash`, `cash`, `icon`,
+`wave`, `gas`, `ocean`, `fetch`, `ripple`. Checked against the wordlist, none
+of the 10 appears in any 2020 written surface recovered so far. If even one is
+a list element, every sweep in this folder was drawing from an incomplete pool
+and its negative result says nothing about the phrase.
+
+Method, for anyone with the video and a normal desktop: download it, sample
+frames at 1 per second, read the text in each frame, intersect the result with
+the BIP-0039 English wordlist, and add anything new to the pool before
+re-running RO1. Optical character recognition on 1 frame per second is enough;
+a person watching once and writing down the visible tickers gets most of it.
+Check explicitly for `cloud`, which decides established fact 3 in the README,
+and for the 10 coin words above.
+
+What would confirm it: a dictionary word legible on screen that appears in no
+written surface, which then completes a phrase through `tools/oracle.py`.
+What would kill it: a complete frame read yielding no dictionary word absent
+from the already-known pool. That is a real exhaustion point, unlike a
+re-read of prose.
+Cost: about an hour of directed work, no compute budget.
+
+## 2. Extend the swept word pool with connecting words (liaisons)
+
+Unchanged in substance from the previous lead 1, still open, now second because
+lead 1 is cheaper and can invalidate the pool this lead extends.
+
+Every completed sweep draws its non-anchor words from full words in the
+recovered text. None includes the short connecting words from the same
+sentences: prepositions, articles and conjunctions such as "there", "will",
+"also", "you", "more", "can", "then" on the video side, or "only", "because",
+"there", "like" on the post side. Sized at 15 and 14 words per side,
+1.36x10^10 derivations, about 4.8 hours at 792,000 derivations/second.
+
+Note the interaction with RO1: "also" is one of only 2 dictionary words lying
+between `fog` and `parrot` in the video text, and RO1 already covered every
+reading-order arrangement containing it. So the part of this lead that overlaps
+the reading-order model is closed; what is open is the free-order remainder.
 
 What would confirm it: a match within the extended set.
-What would kill it: exhausting the extended set with 0 match, the same witness
-protocol as every prior sweep.
+What would kill it: exhausting the extended set with 0 match, under the same
+witness protocol as every prior sweep.
 Cost: hours on one rented GPU.
 
-## 2. Extend further to substrings of longer words
+## 3. Re-check the already-enumerated survivors on other derivation paths
 
-The author, asked directly whether a list word could be hidden inside a
-longer written word, answered yes and gave "possible" inside its own
-negation, formed with the prefix "im-", as his own example, though the
-surrounding conversation suggests he may have
-meant the paraphrase-hint mechanism rather than a substring mechanism (see
-README, "What is understood"). This is confirmed as an open question, not a
-confirmed mechanism. If it is real, plausible substrings already identified in
-the source texts include "cat" (cattle), "ill" (will), "hen" (then), "like"
-(likely), "cause" and "use" (because), "health" (healthy), "hunt" (hunter),
-and "inner" (dinner). The private research's own P3 estimate for a
-substring-inclusive sweep, before the metadata extension, was 21/20 words per
-side, 2.78x10^11 derivations, about 77 hours on one GPU (later re-priced
-downward once a faster kernel was validated at 792,000 derivations/second).
+Cheap, decisive, and never run. Every sweep in this folder derives only
+`m/44'/60'/0'/0/0`, the MetaMask default first account. The escrow is stated to
+be a MetaMask wallet, so that is the correct first guess, but if the author
+funded the challenge from the second account in the same wallet, or from a
+second wallet in the same application, then every negative in
+`analysis/tested.md` is a negative about the wrong address and says nothing
+about the phrase.
+
+Paths worth checking: `m/44'/60'/0'/0/1`, `m/44'/60'/0'/0/2`,
+`m/44'/60'/1'/0/0`, `m/44'/60'/2'/0/0`.
+
+The cost is low because the expensive half of the work is already done. The
+PBKDF2 seed stretch dominates a BIP39 derivation; changing the path only
+repeats the child key derivation and the address hash. Re-running the 10,484,919
+RO1 survivors on 4 extra paths costs about 28 percent of the original run, not
+400 percent.
+
+What would confirm it: a match on any of the 4 paths.
+What would kill it: 0 match across all 4, which upgrades every existing
+negative in this folder from "negative at the default path" to "negative across
+the plausible MetaMask path family".
+Cost: about 4 hours on 2 CPU cores, seconds on a GPU. This is the best value
+experiment currently available in this folder.
+
+## 4. Substrings of longer written words
+
+Demoted from lead 2, with a correction to the reason it was ranked so high.
+
+**The correction.** This lead used to say that the author, asked whether a list
+word could be hidden inside a longer written word, "answered yes and gave
+"possible" inside its own negation, formed with the prefix "im-", as his own
+example". Reading the comment thread directly shows the nesting example belongs
+to the reader who asked the question, not to the author. The author's reply is
+"1. Yes for example usa could be united states in hints , but wikk have corect
+word in text at chalange." His own example is an abbreviation, it is offered
+about hints, and he contrasts it with the challenge text, which "wikk have corect
+word". A second thread has the same shape: asked how the first word can be
+"Netherlands" when that is not in the wordlist, he answers that the exact word
+is in the post. Read together, the 2 replies describe hints that gloss a word,
+not text that conceals one inside another. Both are quoted in full in
+`clues/author-posts.md`.
+
+So "yes" is real but its subject is contested. The substring mechanism is now a
+reader's hypothesis that the author did not contradict, which is weaker
+evidence than an author-stated mechanism.
+
+**A second argument against it.** All 5 confirmed list words appear as whole
+tokens: `dutch` and `fiber` in the post body, `fog` and `parrot` in the video
+description, `fork` in the post's tags. Not one of the 5 is a substring of a
+longer word. If the author had used a substring mechanism across 12 elements,
+seeing 5 of 5 come out as whole tokens has probability roughly 0.065 under a
+simple model where each element is independently whole or nested. That is weak
+evidence against the mechanism rather than proof, and it should be red-teamed:
+the 5 known words are exactly the ones the author chose to write hints for, and
+a hint is easier to write for a whole word, so the sample is not drawn at
+random from the 12. The argument survives that objection only in weakened form.
+
+If the mechanism is real, substrings already identified include "cat" (cattle),
+"ill" (will), "hen" (then), "like" (likely), "cause" and "use" (because),
+"health" (healthy), "hunt" (hunter) and "inner" (dinner). Sized at 21 and 20
+words per side, 2.78x10^11 derivations, about 4.1 days at 792,000
+derivations/second. Sweep RO2 in `analysis/tested.md` has already covered the
+reading-order corner of this space, 582,725 derivations, 0 match; that leaves
+the free-order remainder, which is the bulk of it.
 
 What would confirm it: a match within the substring-extended set.
-What would kill it: exhausting it with 0 match.
-Cost: on the order of a day on one rented GPU at the validated 792,000
-derivations/second rate; re-price before running, since kernel throughput
-changes this estimate directly.
+What would kill it: exhausting it with 0 match. Re-price before running, since
+throughput changes the estimate directly.
+Cost: on the order of a day on one rented GPU.
 
-## 3. Read the video and post one more time for a metadata-style hidden word
+## Retired: position 5 is settled
 
-If leads 1 and 2 both return negative, the most likely remaining explanation
-is that one word lives in a part of the source material not yet identified as
-a metadata surface, the same way the blog post's tags were missed until
-2026-08-15. The video's own metadata (its tags, description formatting, or
-on-screen text) and the post's remaining unread surfaces (any HTML attribute
-resembling `article:tag`, image alt text) have not been re-examined with the
-same "check every metadata field" method that found `fork` in the post's tags.
-
-What would confirm it: a new word found in an unexamined metadata field,
-tested through `tools/oracle.py` after being combined with the already-mapped
-words.
-What would kill it: a full metadata re-read producing nothing new; there is no
-natural exhaustion point for this lead beyond a careful, complete pass.
-Cost: an hour of directed reading, not a sweep.
-
-## Community correction: R1 pool provenance (issue #10)
-
-HPreziosa (issue #10) grepped the 2020 Wayback captures of the video and blog and reports
-that three words in the R1 pool are mis-sourced in the "title and hook line" row of
-`tested.md`:
-
-- `top` is not in the video title or og:description; it appears in the blog body ("top ten
-  altcoins") and in the video description trailer ("top mining equipment").
-- `finish` does not appear as a bare stem; only `finished` does, in the og:description
-  ("Crypto Winter finished?"), so it is a morphological derivative, not a literal.
-- `cloud` appears in no authored 2020 surface; the README itself says only `fog` and `lake`
-  do, yet still carries `cloud` on semantic grounds.
-
-Verified against the archives on 2026-08-21 (Wayback `20200626184951` of the video,
-`20201026062858` of the blog), all three confirmed:
-
-- the video title is "10 ETH challenge | Ethereum Parabolic | Bitcoin generator portfolio
-  update !?"; `top` is not in it. `top` appears only as "top altcoins", "top mining", and
-  "top supporting" in the video description, and as "top ten altcoins" in the blog body.
-- the bare stem `finish` appears in neither surface; only `finished` does, nine times in the
-  video ("Crypto Winter finished?").
-- `cloud` has zero occurrences in either the video or the blog.
-
-Consequence for the pool: `top` and `finish` stay in the corpus but are re-sourced (the
-description and the blog body, not the title; `finish` as an inflection of `finished`). More
-usefully, since `cloud` is in no authored 2020 surface while `fog` is ("dark fog on the
-lake"), position 5 resolves to `fog`, and `cloud` is dropped as a candidate.
+An earlier open question asked whether position 5 holds `fog` or `cloud`. Treat
+it as `fog`. Hint 3 describes condensed water droplets; 3 BIP-0039 words fit
+that description, `fog`, `cloud` and `vapor`, and of the 3 only `fog` appears in
+any recovered 2020 written surface, at index 25 of the video description. The
+author's own reply that the challenge text carries the exact word points the
+same way: a hint may gloss, the text does not. `cloud` remains worth a glance
+during lead 1, because on-screen text is the one channel that could still
+produce it, and if it does appear there this retirement should be reopened.

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/tested.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/analysis/tested.md
@@ -80,6 +80,125 @@ ordering under the confirmed anchors. It does not cover connecting words
 (prepositions, articles), substrings of longer words, or metadata beyond the
 tags, title and hook line already identified.
 
+## RO1 -- the complete reading-order model over the full recovered 2020 text (2026-08-20)
+
+Contributed. This is the first sweep to define its space by a closed form and
+then enumerate exactly that count, so the coverage claim is checkable rather
+than asserted.
+
+Hypothesis: all 12 elements are whole words appearing in the recovered 2020
+written surfaces, 6 from the video side and 6 from the post side, and the
+elements keep the order in which they are written. The 3 anchors are fixed as
+already established: `dutch` at position 1, `fog` at position 5, `parrot` at
+position 12. `fork` appears only in the post's tag "ethereum fork", which has
+no position in running prose, so it is given a free slot among the post's 6.
+
+Word pool, built from the archived 2020 text and its metadata, not from the 5
+planted sentences alone: 39 dictionary words on the video side, 83 on the post
+side, 106 distinct across both.
+
+Space, closed form. All counts are exact integers, no rounding:
+
+```
+video word sets   = C(25,2)*C(2,2) + C(25,3)*C(2,1) = 300 + 4,600 = 4,900
+templates         = C(3,2)*C(6,2) = 45  for the (2 before fog, 2 after) shape
+                    C(3,3)*C(6,1) = 6   for the (3 before fog, 1 after) shape
+video pairs       = 300*45 + 4,600*6 = 13,500 + 27,600 = 41,100
+post word sets    = C(18,3) = 816
+fork slot choices = 5
+arrangements      = 41,100 * 816 * 5 = 167,688,000
+checksum-valid    = 10,484,919
+```
+
+Method: enumerate all 167,688,000 arrangements in 3,264 units, filter by the
+BIP39 checksum in stdlib, derive every survivor at `m/44'/60'/0'/0/0` and
+compare against the escrow address.
+
+Script: `tools/sweep_reading_order.py`, which re-enumerates the identical space
+in 816 larger units (1 per post word set) without the novelty banding the
+original run used to order its units. `--size` prints the closed form and
+checks that the layout enumeration reproduces it. `--selftest` verifies the
+wordlist digest, measures the checksum acceptance rate on a real unit, and
+plants a candidate then requires the pipeline to recover it. Enumeration and
+the checksum filter are stdlib, so both of those run without `bip_utils`;
+derivation is delegated to `tools/oracle.py`. On a hit the phrase is written to
+a file and deliberately not printed to the log.
+
+Certification. The enumerated arrangement count equals the closed form to the
+unit, in all 7 novelty bands separately and in total. Duplicate arrangements
+across units: 0. The observed checksum pass rate is 6.254 percent against a
+predicted 6.25 percent, which is the independent check that the enumeration and
+the checksum filter agree. A known-answer test was run on the derivation engine
+before and after: `abandon` 11 times plus `about` derives
+`0x9858EfFD232B4033E47d90003D41EC34EcaEda94`, on both the fast engine and a
+separate reference engine, with 0 disagreements between the two over the whole
+run. A synthetic witness was planted in each unit that could hold one and
+recovered through the identical pipeline: OK 1,062, SKIP 2,202 (units whose
+shape admits no witness), NONE 0.
+
+Result: 10,484,919 derivations, **0 match**.
+
+Rate: measured 207 to 497 derivations/second on 2 CPU cores, so about 14 hours
+of elapsed time here. The same space is about 13 seconds at the 792,000
+derivations/second rate this repository's earlier sweeps were run at. The space
+is small; the point of this sweep is that it is now closed and witnessed, not
+that it was expensive.
+
+## RO2 -- the same reading-order model extended to substrings (2026-08-20)
+
+Contributed. A bounded probe of lead 2, not a closure of it.
+
+Hypothesis: as RO1, but the pool also admits substrings of longer written words
+where the substring is itself a dictionary word.
+
+Space: 9,334,500 arrangements, 582,725 checksum-valid derivations. Same
+anchors, same order constraint, same witness protocol.
+
+Result: 0 match.
+
+This does **not** close lead 2. It covers only the substrings already listed in
+`analysis/leads.md` under the reading-order constraint. The free-order
+substring space named in that lead is about 2.8x10^11 derivations and remains
+open.
+
+## What RO1 changes about the remaining space
+
+Reading order was the assumption that made any of this searchable. With it
+dropped, the same pool and the same 3 anchors give:
+
+```
+C(38,4) = 73,815          free choice of the 4 unplaced video words
+C(82,3) = 88,560          free choice of the 3 unplaced post words
+9!      = 362,880         free arrangement of the 9 unanchored positions
+arrangements   = 73,815 * 88,560 * 362,880 = 2.3722x10^15
+checksum-valid = 1.4826x10^14
+```
+
+At 792,000 derivations/second that is 5.9 years on one GPU. At 12,600
+derivations/second, the rate 64 rented CPU cores would give, it is 373 years.
+Both figures are quoted so that nobody prices this the way an earlier private
+estimate did, which put the same space at 9.1x10^9 arrangements and concluded
+that a weekend of rented CPU would cover it. That estimate was low by a factor
+of about 2.6x10^5.
+
+The consequence for this folder's ranking: the 2 open sweep leads, liaisons and
+substrings, are together about 0.2 percent of the free-order space. They are
+worth running because they are cheap, not because covering them would leave
+much behind. If the phrase is not in them, no amount of rented compute reaches
+the rest. What remains after them is a reading problem, so the leads have been
+re-ordered to put reading first.
+
+One sharper result from inside the reading-order model, offered as evidence
+rather than as a conclusion. With `fog` at 5 and `parrot` at 12 and order
+preserved, the 4 free video words must split k of them before `fog` and m of
+them between `fog` and `parrot`, with k+m=4 and k at most 3. Only 2 dictionary
+words lie between `fog` and `parrot` in the video text, `lake` and `also`, so m
+is at most 2, which forces (k,m) to be (2,2) or (3,1) and therefore forces at
+least one of `lake` or `also` into the phrase. RO1 covers 100 percent of that
+space and is negative. So either the pool is incomplete on the video side, or
+order is not preserved. Those are the only 2 options left inside this model,
+and lead 1 is the cheaper of the 2 to test.
+
 ## Earlier, smaller sweeps (pre-metadata, dates not individually re-timestamped
 in the source record, all prior to 2026-08-15)
 
@@ -104,10 +223,38 @@ in the source record, all prior to 2026-08-15)
 
 ## What none of this has tested
 
-Every sweep above assumes the 12 elements come from the 2 published texts
-(including their metadata). None of it tests the possibility that an element
-is a substring of a longer written word (the author's own comment about
-"possible" as a substring of its own negation, formed with the prefix "im-",
-is acknowledged but not confirmed as a real mechanism; see README), or that a
-word exists in material outside these
-2 texts and their direct metadata.
+1. Text shown on screen in the challenge video. The author names this as a
+   channel in his own spoken rules for the challenge, at 5:22 to 5:38 of
+   .../w4mpiuBP_aY: the words "could be you know written in the video on the
+   screen so read carefully". Every sweep in this file, including RO1 and RO2,
+   draws its pool from the description, title, tags and post body only. No
+   frame of the video image has been read. This is the largest untested channel
+   and it is not a sweep, it is a reading task.
+
+2. Free ordering over the full recovered pool. Sized above at 1.4826x10^14
+   derivations. Open and not purchasable.
+
+3. Liaisons and substrings under free ordering. The 2 sweep leads, about
+   1.4x10^10 and 2.8x10^11 derivations.
+
+4. Derivation paths other than `m/44'/60'/0'/0/0`. Every sweep in this file
+   uses the MetaMask default first account. The escrow is stated to be a
+   MetaMask wallet, so this is the right first guess, but a phrase already
+   enumerated and rejected at index 0 would also have been rejected at index 1.
+   Re-checking the already-enumerated survivors at
+   `m/44'/60'/0'/0/1`, `m/44'/60'/0'/0/2`, `m/44'/60'/1'/0/0` and
+   `m/44'/60'/2'/0/0` costs about 28 percent of the original derivation work,
+   because the seed is already computed and only the child key derivation
+   repeats.
+
+5. Material outside the 2 published texts and their metadata.
+
+A correction to what this section used to say. It attributed to the author an
+example of a list word hidden inside a longer written word, specifically a word
+nested inside its own negation formed with the prefix "im-". Reading the comment
+thread directly shows that example was written by the reader asking the
+question, not by the author. The author's own example in that reply is "usa" for
+"united states", an abbreviation in a hint, and he adds that the challenge text
+"wikk have corect word". See `clues/author-posts.md` for both replies in full.
+The substring mechanism is still possible; it is just not author-stated, and the
+lead resting on it has been demoted accordingly.

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/clues/author-posts.md
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/clues/author-posts.md
@@ -54,17 +54,81 @@ at 17:28: "the keyword is fork, f-o-r-k. It's not necessarily in its place in
 the order." Both official captions and an independent transcription agree on
 the spelling despite both hearing "keyboard" for "keyword".
 
-## What the author has said in comments (paraphrased, not verbatim)
+## What the author has said in comments, verbatim
 
-Asked whether all 12 words are written somewhere: yes, everything is under the
-video or in the blog post.
-Asked about decoy entries: confirmed the catalogue words present in his texts
-are mostly real, "maybe two added on top to complicate".
-Asked whether audio matters: in 2020, before hints 4 and 5 existed, he said
-only the written elements were needed.
-Asked whether hints can be paraphrases rather than exact words: yes; reading
-the texts finds the actual word.
-Confirmed: an element appearing in both the video and the post stays valid,
-and hint 4's word has no fixed position in the final list.
-Confirmed to a reader asking if only the order remains to be guessed: all
-elements are under the video and in the blog post.
+Recovered 2026-08-21 by reading the comment threads under the hint 5 video
+directly. This section replaces an earlier paraphrase of the same threads. The
+paraphrase was right on two points and wrong on a third, so the exact wording is
+reproduced here: the nesting lead in `analysis/leads.md` rests on the first
+reply below.
+
+**Thread 1.** A reader (`@nokiasixdotone1273`) asked three questions in one
+comment: whether a list word can be hidden inside a longer written word, giving
+as his own example a word nested inside its own negation formed with the prefix
+"im-"; whether a word appearing in both the video and the post is invalidated;
+and whether hint 4's word, like hint 5's, has an unconfirmed position. The
+author's reply, in full, spelling his:
+
+> "1. Yes for example usa could be united states in hints , but wikk have corect
+> word in text at chalange. 2 no it doeesnt. 3 it coukd be in any positon from 12
+> seed"
+
+**Thread 2.** Asked by `@mirosomething` how the first word can be "Netherlands"
+when "Netherlands" is not in the English wordlist:
+
+> "It not necceseraly need to be exact word if you would read a post you would
+> figure it our exact word."
+
+**The correction this forces.** The example inside reply 1 is the author's own
+and it is "usa" for "united states". That is an abbreviation, not a word nested
+inside a longer word. The nesting example belongs to the reader who asked the
+question. The earlier paraphrase of this thread, and the lead built on it,
+attributed the nesting example to the author; on this evidence that attribution
+is wrong. What he actually wrote is contrastive: that looser form is allowed "in
+hints", but the challenge text "wikk have corect word". Thread 2 has the same
+shape, with the hint saying "Netherlands" and the text carrying `dutch`. Read
+together the two replies describe hints that gloss a word, not text that hides
+one inside another. `analysis/leads.md` has been re-ranked accordingly.
+
+Two other points in reply 1 confirm what the earlier paraphrase already said: a
+word may appear in both sources and stay valid, and hint 4's word has no
+confirmed position.
+
+**Thread 3, unanswered.** On 2026-08-19 a reader (`@9PashaE6ashu`) argued that
+the challenge is not worth searching by volume, and said of hint 5: "From where
+fork was taken? It isn't mentioned anywhere (not in blog, neither in video). It
+just a random word." There is no author reply as of 2026-08-21. The premise is
+answerable from this file: `fork` is written, as the blog tag "ethereum fork"
+quoted in the footer above. Anyone reading only the visible prose, and not the
+page metadata, would reach exactly that reader's conclusion.
+
+## The author on text shown on screen
+
+Spoken audio of the challenge video, https://www.youtube.com/watch?v=w4mpiuBP_aY,
+at 5:22 to 5:38, transcribed 2026-08-20:
+
+> "there will be six seed phrase words from the wallet address, totally 12 seed
+> phrase words. It could be anywhere in the description, with your description
+> title, it could be you know written in the video on the screen so read
+> carefully."
+
+This names four video side channels: description, title, tags, and text shown on
+screen. It does not say the words are in the spoken audio. The written rules in
+the hint 5 video description agree, listing "description, tags, title, video
+basically could be anywhere in this video".
+
+The description, the title and the tags have all been read. The video image has
+not. See `analysis/leads.md` lead 1.
+
+## Written challenge rules
+
+Quoted from the hint 5 video description as archived by the Wayback Machine on
+2022-12-08. This is the author's own statement of the format:
+
+> "12 wallet seed words- 6 are hidden in video .../w4mpiuBP_aY (description,
+> tags, title, video basically could be anywhere in this video) 6.words are
+> hidden in original post"
+
+The 6 and 6 split is therefore the author's own, not an inference. The escrow
+address given in the same rules block matches the address in `puzzle.json` and
+in `tools/oracle.py`.

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/data/reading-order-pool.json
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/data/reading-order-pool.json
@@ -1,0 +1,71 @@
+{
+  "_note": "Derived index for the reading-order model in tools/sweep_reading_order.py. These are the BIP-0039 dictionary words that appear in the recovered 2020 source surfaces, listed in the order they are written, restricted to the ranges the model uses. This is a derived index, not a reproduction of the source text and not a copy of the BIP-0039 wordlist.",
+  "_derived_from": {
+    "video": "video description as archived 2020-05-28",
+    "post": "blog post body as archived 2020-05-28"
+  },
+  "anchors": {
+    "dutch": 1,
+    "fog": 5,
+    "parrot": 12
+  },
+  "video_pre_fog": [
+    "update",
+    "winter",
+    "follow",
+    "chat",
+    "original",
+    "post",
+    "account",
+    "share",
+    "this",
+    "video",
+    "more",
+    "great",
+    "tiny",
+    "you",
+    "address",
+    "seed",
+    "hidden",
+    "title",
+    "task",
+    "will",
+    "unlock",
+    "claim",
+    "expect",
+    "easy",
+    "there"
+  ],
+  "video_between_fog_and_parrot": [
+    "lake",
+    "also"
+  ],
+  "post_reading_order_after_dutch": [
+    "cattle",
+    "forest",
+    "wood",
+    "fiber",
+    "like",
+    "rib",
+    "roast",
+    "dinner",
+    "fresh",
+    "sponsor",
+    "video",
+    "word",
+    "seed",
+    "phrase",
+    "hidden",
+    "title",
+    "expect",
+    "easy",
+    "address"
+  ],
+  "counts": {
+    "video_pre_fog": 25,
+    "video_between_fog_and_parrot": 2,
+    "post_reading_order_after_dutch": 19
+  },
+  "fork_note": "fork appears only in the post tags, which have no position in reading order, so it takes any one of the 5 non-anchor post slots and is not listed here.",
+  "fiber_note": "fiber is a confirmed member from hint 4 and sits at rank 3 of the list above, so it keeps its reading-order place and is not a free choice."
+}

--- a/1-big-prizes/guntis-vitolins-metamask-8-6eth/tools/sweep_reading_order.py
+++ b/1-big-prizes/guntis-vitolins-metamask-8-6eth/tools/sweep_reading_order.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+sweep_reading_order.py -- the complete reading-order model for this challenge.
+
+WHAT THIS SWEEPS
+
+Hypothesis: all 12 elements are whole words appearing in the recovered 2020
+written surfaces, 6 from the video side and 6 from the post side, and they keep
+the order in which they are written. The 3 author-stated anchors are fixed:
+`dutch` at position 1, `fog` at position 5, `parrot` at position 12.
+
+`fork` is treated as a floater. It appears only in the post's tag "ethereum
+fork", and a tag has no position in running prose, so it has no reading-order
+slot and may occupy any of the 5 non-anchor post slots. `fiber` by contrast
+sits after `dutch` in post reading order, so it needs no exemption. That is
+consistent with hint 5 naming only `fork` as out of place.
+
+THE SPACE, AS A CLOSED FORM
+
+  video word sets   = C(25,2)*C(2,2) + C(25,3)*C(2,1) = 300 + 4,600 = 4,900
+  templates         = C(3,2)*C(6,2) = 45  for the (2 pre-fog, 2 mid) shape
+                      C(3,3)*C(6,1) = 6   for the (3 pre-fog, 1 mid) shape
+  video pairs       = 300*45 + 4,600*6 = 13,500 + 27,600 = 41,100
+  post word sets    = C(18,3) = 816
+  fork slot choices = 5
+  arrangements      = 41,100 * 816 * 5 = 167,688,000
+
+About 1 arrangement in 16 passes the BIP39 checksum, so expect close to
+1.048x10^7 derivations. `--size` prints these numbers and checks that the
+layout enumeration reproduces them before any work is done.
+
+A CONSTRAINT THAT FALLS OUT OF THE ANCHORS
+
+With `fog` at 5 and `parrot` at 12 and order preserved, the 4 free video words
+split k before `fog` and m between `fog` and `parrot`, with k+m=4. Only 2
+dictionary words lie between `fog` and `parrot` in the video text, so m is at
+most 2 and k is at most 3, forcing (k,m) to be (2,2) or (3,1). Every
+arrangement in this space therefore contains at least 1 of those 2 mid words.
+If this sweep is negative over its whole space, then either the pool is
+incomplete or order is not preserved. See `analysis/leads.md`.
+
+UNITS AND RESUMPTION
+
+1 unit = 1 post word set, so 816 units of 205,500 arrangements each. The log is
+flushed after every unit, so an interrupted run resumes with `--resume`. The
+original run of this space used 3,264 smaller units ordered by how far each
+candidate strays from the 5 planted sentences; the space enumerated is
+identical.
+
+USAGE
+
+  python3 tools/sweep_reading_order.py --size
+  python3 tools/sweep_reading_order.py --selftest
+  python3 tools/sweep_reading_order.py --run --log sweep.tsv
+  python3 tools/sweep_reading_order.py --run --log sweep.tsv --resume
+
+The BIP-0039 English wordlist is not included in this repository. Supply it
+with `--wordlist PATH` or in `$BIP39_WORDLIST`. Its expected SHA-256 is
+checked, so a wrong or reordered list is rejected rather than silently used.
+
+Dependencies: stdlib for enumeration and the checksum filter, which is why
+`--size` and most of `--selftest` run anywhere. Derivation is delegated to
+`tools/oracle.py` in this same folder, which needs `bip_utils`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import math
+import os
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FOLDER = os.path.dirname(HERE)
+
+WORDLIST_SHA256 = "2f5eed53a4727b4bf8880d8f3f199efc90e58503646d9ff8eff3a2ed3b24dbda"
+TARGET_ADDRESS = "0x9c2f44efad0c1e852a09df9939e6daf061140caf"
+
+# 0-based seed positions.
+DUTCH, FOG, PARROT = 0, 4, 11
+PRE_SLOTS = (1, 2, 3)
+MID_SLOTS = (5, 6, 7, 8, 9, 10)
+
+SHIFT = [11 * (11 - p) for p in range(12)]
+ENT_MASK = (1 << 128) - 1
+
+
+def load_wordlist(path):
+    with open(path, "rb") as fh:
+        raw = fh.read()
+    words = raw.decode("utf-8").split()
+    if len(words) != 2048:
+        sys.exit("wordlist has %d words, expected 2048" % len(words))
+    digest = hashlib.sha256(("\n".join(words) + "\n").encode("utf-8")).hexdigest()
+    if digest != WORDLIST_SHA256:
+        sys.exit("wordlist SHA-256 is %s, expected the canonical %s"
+                 % (digest, WORDLIST_SHA256))
+    return words, {w: i for i, w in enumerate(words)}
+
+
+def load_pool(path):
+    with open(path, encoding="utf-8") as fh:
+        d = json.load(fh)
+    pre = d["video_pre_fog"]
+    mid = d["video_between_fog_and_parrot"]
+    post = d["post_reading_order_after_dutch"]
+    free = [w for w in post if w != "fiber"]
+    if (len(pre), len(mid), len(post), len(free)) != (25, 2, 19, 18):
+        sys.exit("pool shape is %d/%d/%d/%d, expected 25/2/19/18; the closed form "
+                 "assumes those sizes, so re-derive it before running"
+                 % (len(pre), len(mid), len(post), len(free)))
+    if "fiber" not in post:
+        sys.exit("fiber is missing from the post reading order; it is a confirmed "
+                 "member and must keep its written place")
+    # Reading order is what the model is testing, so the position of fiber
+    # relative to the free words is load bearing, not cosmetic.
+    order = {w: i for i, w in enumerate(post)}
+    return pre, mid, free, order
+
+
+def closed_form():
+    c = math.comb
+    vsets = c(25, 2) * c(2, 2) + c(25, 3) * c(2, 1)
+    t22 = c(3, 2) * c(6, 2)
+    t31 = c(3, 3) * c(6, 1)
+    vpairs = c(25, 2) * c(2, 2) * t22 + c(25, 3) * c(2, 1) * t31
+    bsets = c(18, 3)
+    return {"video_sets": vsets, "templates_2_2": t22, "templates_3_1": t31,
+            "video_pairs": vpairs, "post_sets": bsets, "fork_slots": 5,
+            "arrangements": vpairs * bsets * 5}
+
+
+def shapes():
+    return [(k, 4 - k) for k in range(0, 4) if 0 <= 4 - k <= 2]
+
+
+def layouts(k, m):
+    """One layout is a video slot assignment plus the fork choices it allows."""
+    out = []
+    for pre in itertools.combinations(PRE_SLOTS, k):
+        for mid in itertools.combinations(MID_SLOTS, m):
+            vpos = pre + (FOG,) + mid + (PARROT,)
+            used = set(vpos) | {DUTCH}
+            post = [p for p in range(12) if p not in used]
+            if len(post) != 5:
+                sys.exit("layout produced %d post slots, expected 5" % len(post))
+            forks = [(f, tuple(p for p in post if p != f)) for f in post]
+            out.append((vpos, forks))
+    return out
+
+
+def video_sets(pre, mid, index_of):
+    """Word-index tuples for the free video slots, pre words then mid words,
+    each group in written order, keyed by shape."""
+    by_shape = {}
+    for (k, m) in shapes():
+        rows = []
+        for a in itertools.combinations(pre, k):
+            for b in itertools.combinations(mid, m):
+                rows.append(tuple(index_of[w] for w in a + b))
+        by_shape[(k, m)] = rows
+    return by_shape
+
+
+def build_layouts():
+    return {(k, m): layouts(k, m) for (k, m) in shapes()}
+
+
+def scan_unit(bset, pool, index_of, words, lay, vsets, order, derive, target,
+              witness_cap=1):
+    """Sweep 1 post word set across every video pair and fork slot.
+
+    Returns (arrangements, derivations, hit_mnemonic_or_None, witness_state).
+    The witness state is OK when an independently recomputed address for the
+    first derived candidate agrees, so a unit that reports OK has proved its own
+    pipeline live rather than assuming it.
+    """
+    ordered4 = [index_of[w] for w in
+                sorted(list(bset) + ["fiber"], key=lambda w: order[w])]
+    fork_i = index_of["fork"]
+    base_anchor = ((index_of["dutch"] << SHIFT[DUTCH])
+                   + (index_of["fog"] << SHIFT[FOG])
+                   + (index_of["parrot"] << SHIFT[PARROT]))
+    sha = hashlib.sha256
+    n = d = 0
+    wstate = "NONE"
+    witnessed = 0
+    for (k, m), rows in vsets.items():
+        if not rows:
+            continue
+        for vpos, forks in lay[(k, m)]:
+            free_slots = [SHIFT[p] for p in vpos[:k] + vpos[k + 1:-1]]
+            for fslot, others in forks:
+                base = base_anchor + (fork_i << SHIFT[fslot])
+                for w4, p in zip(ordered4, others):
+                    base += w4 << SHIFT[p]
+                for v in rows:
+                    acc = base
+                    for wi, sh in zip(v, free_slots):
+                        acc += wi << sh
+                    n += 1
+                    ent = ((acc >> 4) & ENT_MASK).to_bytes(16, "big")
+                    if (sha(ent).digest()[0] >> 4) != (acc & 0xF):
+                        continue
+                    d += 1
+                    mnemonic = " ".join(
+                        words[(acc >> SHIFT[p]) & 0x7FF] for p in range(12))
+                    address = derive(mnemonic)
+                    if witnessed < witness_cap:
+                        witnessed += 1
+                        wstate = "OK" if _recheck(mnemonic, address) else "FAIL"
+                    elif wstate == "NONE":
+                        wstate = "SKIP"
+                    if address == target:
+                        return n, d, mnemonic, wstate
+    return n, d, None, wstate
+
+
+def _recheck(mnemonic, address):
+    """Independent confirmation that the derivation is reproducible: re-derive
+    through a fresh call and require the same answer. A real cross-engine check
+    is stronger; this at least catches a stateful or cached derivation."""
+    return _oracle().derive_address(mnemonic) == address
+
+
+_ORACLE = None
+
+
+def _oracle():
+    global _ORACLE
+    if _ORACLE is None:
+        sys.path.insert(0, HERE)
+        try:
+            import oracle
+        except ImportError as exc:
+            sys.exit("cannot import tools/oracle.py (%s). Derivation needs "
+                     "bip_utils; --size and the stdlib parts of --selftest do "
+                     "not." % exc)
+        _ORACLE = oracle
+    return _ORACLE
+
+
+def cmd_size(args):
+    cf = closed_form()
+    for key in ("video_sets", "templates_2_2", "templates_3_1", "video_pairs",
+                "post_sets", "fork_slots", "arrangements"):
+        print("%-16s %s" % (key, format(cf[key], ",")))
+    lay = build_layouts()
+    counted = 0
+    for (k, m), rows in lay.items():
+        print("shape (%d,%d): %d layouts" % (k, m, len(rows)))
+        counted += len(rows) * (math.comb(25, k) * math.comb(2, m)) * 5
+    counted *= cf["post_sets"]
+    print("enumerated layouts reproduce the closed form: %s"
+          % ("yes" if counted == cf["arrangements"] else
+             "NO (%s)" % format(counted, ",")))
+    print("expected derivations at 1 in 16: about %s"
+          % format(cf["arrangements"] // 16, ","))
+    if counted != cf["arrangements"]:
+        return 1
+    return 0
+
+
+def cmd_selftest(args):
+    ok = True
+
+    cf = closed_form()
+    part = cf["arrangements"] == 167688000
+    print("closed form gives 167,688,000 arrangements: %s"
+          % ("OK" if part else "FAIL"))
+    ok = ok and part
+
+    part = cmd_size(argparse.Namespace()) == 0
+    print("layout enumeration agrees with the closed form: %s"
+          % ("OK" if part else "FAIL"))
+    ok = ok and part
+
+    words, index_of = load_wordlist(args.wordlist)
+    print("wordlist is the canonical BIP-0039 English list: OK")
+
+    pre, mid, free, order = load_pool(args.pool)
+    part = set(mid) == {"lake", "also"}
+    print("the 2 words between fog and parrot are lake and also: %s"
+          % ("OK" if part else "FAIL"))
+    ok = ok and part
+
+    for w in ("dutch", "fog", "parrot", "fiber", "fork"):
+        if w not in index_of:
+            print("anchor word %s is not in the wordlist: FAIL" % w)
+            ok = False
+
+    # Checksum acceptance rate, measured on real enumerated arrangements rather
+    # than assumed. A rate far from 1 in 16 means the packing is wrong.
+    lay = build_layouts()
+    vsets = video_sets(pre, mid, index_of)
+    bset = tuple(free[:3])
+    n, d, hit, _ = scan_unit(bset, None, index_of, words, lay, vsets, order,
+                             lambda mn: "0x" + "0" * 40, TARGET_ADDRESS,
+                             witness_cap=0)
+    rate = d / n if n else 0.0
+    part = abs(rate - 1 / 16) < 0.004 and n == 205500
+    print("1 unit enumerates 205,500 arrangements, %d pass the checksum, "
+          "rate %.4f against 0.0625: %s" % (d, rate, "OK" if part else "FAIL"))
+    ok = ok and part
+
+    # Plant a witness: take a real enumerated candidate, make its own address
+    # the target, and require the pipeline to find it. This is the check that
+    # a negative result from this script is worth anything.
+    try:
+        derive = _oracle().derive_address
+    except SystemExit:
+        print("derivation is unavailable here, so the planted-witness check and "
+              "the canonical vector check were not run. A negative produced in "
+              "this environment would be UNCERTIFIED.")
+        print("SELFTEST INCOMPLETE")
+        return 1 if not ok else 2
+
+    vector = " ".join(["abandon"] * 11 + ["about"])
+    part = derive(vector) == "0x9858effd232b4033e47d90003d41ec34ecaeda94"
+    print("canonical BIP-0039 vector derives its published address: %s"
+          % ("OK" if part else "FAIL"))
+    ok = ok and part
+
+    probe = {}
+
+    def capture(mn):
+        addr = derive(mn)
+        probe.setdefault("first", (mn, addr))
+        return addr
+
+    n, d, hit, wstate = scan_unit(bset, None, index_of, words, lay, vsets, order,
+                                  capture, "0x" + "f" * 40, witness_cap=1)
+    if not probe:
+        print("no candidate was derived, so no witness could be planted: FAIL")
+        ok = False
+    else:
+        planted_mn, planted_addr = probe["first"]
+        n2, d2, hit2, w2 = scan_unit(
+            bset, None, index_of, words, lay, vsets, order,
+            derive, planted_addr, witness_cap=1)
+        part = hit2 == planted_mn and w2 == "OK"
+        print("a planted candidate is recovered through the identical pipeline: "
+              "%s" % ("OK" if part else "FAIL"))
+        ok = ok and part
+
+    if ok:
+        print("SELFTEST OK")
+    return 0 if ok else 1
+
+
+def cmd_run(args):
+    words, index_of = load_wordlist(args.wordlist)
+    pre, mid, free, order = load_pool(args.pool)
+    lay = build_layouts()
+    vsets = video_sets(pre, mid, index_of)
+    derive = _oracle().derive_address
+
+    units = list(itertools.combinations(free, 3))
+    done = set()
+    if args.resume and os.path.exists(args.log):
+        with open(args.log, encoding="utf-8") as fh:
+            for line in fh:
+                cols = line.rstrip("\n").split("\t")
+                if len(cols) > 1 and cols[0] != "unit":
+                    done.add(int(cols[0]))
+        print("resuming, %d of %d units already logged" % (len(done), len(units)))
+
+    new = not os.path.exists(args.log)
+    log = open(args.log, "a", encoding="utf-8")
+    if new:
+        log.write("unit\tarrangements\tderivations\twitness\tseconds\n")
+        log.flush()
+
+    total_n = total_d = 0
+    started = time.time()
+    for idx, bset in enumerate(units):
+        if idx in done:
+            continue
+        if args.deadline and time.time() - started > args.deadline:
+            print("deadline reached, stopping cleanly; rerun with --resume")
+            break
+        t0 = time.time()
+        n, d, hit, wstate = scan_unit(bset, None, index_of, words, lay, vsets,
+                                      order, derive, TARGET_ADDRESS)
+        total_n += n
+        total_d += d
+        log.write("%d\t%d\t%d\t%s\t%.1f\n" % (idx, n, d, wstate, time.time() - t0))
+        log.flush()
+        if hit:
+            # Do not print the phrase. Write it outside the log and stop.
+            path = args.hit
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(hit + "\n")
+            print("MATCH found. The phrase was written to %s and deliberately "
+                  "not printed here. Sweep the wallet before disclosing "
+                  "anything." % path)
+            log.close()
+            return 0
+    log.close()
+    elapsed = time.time() - started
+    print("units run this call: %d, arrangements %s, derivations %s, "
+          "%.1f derivations/second, no match"
+          % (len(units) - len(done) if not args.deadline else 0,
+             format(total_n, ","), format(total_d, ","),
+             total_d / elapsed if elapsed else 0.0))
+    return 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description="reading-order sweep for the "
+                                             "Guntis Vitolins 12-word challenge")
+    ap.add_argument("--wordlist",
+                    default=os.environ.get("BIP39_WORDLIST", "bip39_english.txt"),
+                    help="path to the BIP-0039 English wordlist, 1 word per line")
+    ap.add_argument("--pool",
+                    default=os.path.join(FOLDER, "data", "reading-order-pool.json"),
+                    help="derived pool file")
+    ap.add_argument("--log", default="sweep_reading_order.tsv")
+    ap.add_argument("--hit", default="hit.txt",
+                    help="where a match is written; keep this out of version control")
+    ap.add_argument("--deadline", type=float, default=0.0,
+                    help="stop cleanly after this many seconds")
+    ap.add_argument("--resume", action="store_true")
+    ap.add_argument("--size", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--run", action="store_true")
+    args = ap.parse_args()
+
+    if args.size:
+        return cmd_size(args)
+    if args.selftest:
+        return cmd_selftest(args)
+    if args.run:
+        return cmd_run(args)
+    ap.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This covers the guntis-vitolins-metamask-8-6eth folder only. Per CONTRIBUTING it
is a rule-out plus several leads, so it is a pull request rather than an issue.
It is one PR rather than two because the lead re-ranking is a direct consequence
of the rule-out and reads oddly on its own. Happy to split it if you would
rather review the tested.md row separately.

## What was ruled out

A complete reading-order model over the full recovered 2020 text, not just the 5
planted sentences.

Hypothesis: all 12 elements are whole words written in the recovered 2020
surfaces, 6 per side, keeping written order, with `dutch` at 1, `fog` at 5 and
`parrot` at 12. `fork` is treated as a floater with no reading-order slot,
because it exists only in the post tag "ethereum fork", which is also why hint 5
singles it out and not `fiber`.

Space, as a closed form:

```
video word sets   = C(25,2)*C(2,2) + C(25,3)*C(2,1) = 300 + 4,600 = 4,900
templates         = C(3,2)*C(6,2) = 45   for the (2 pre-fog, 2 mid) shape
                    C(3,3)*C(6,1) = 6    for the (3 pre-fog, 1 mid) shape
video pairs       = 300*45 + 4,600*6 = 41,100
post word sets    = C(18,3) = 816
fork slot choices = 5
arrangements      = 41,100 * 816 * 5 = 167,688,000
checksum-valid    = 10,484,919
result            = 0 match
```

Certification, in the terms AGENTS.md section 9 asks for. The enumerated
arrangement count equals the closed form exactly, in each of the 7 novelty bands
separately and in total, with 0 duplicates across units. The observed checksum
pass rate is 6.254 percent against the predicted 6.25, which is the independent
check that the enumeration and the checksum filter agree. The derivation engine
was validated by known-answer test before and after, `abandon` 11 times plus
`about` deriving `0x9858EfFD232B4033E47d90003D41EC34EcaEda94`, on 2 separate
engines, with 0 disagreements over the run. A synthetic witness was planted in
every unit that could hold one and recovered through the identical pipeline: OK
1,062, SKIP 2,202, NONE 0. So this is a CERTIFIED NEGATIVE, not an assumed one.

A second, smaller sweep extends the same model to substrings, 582,725
derivations, 0 match. That one is explicitly labelled as not closing the
substring lead, since it only covers the reading-order corner of it.

New script, `tools/sweep_reading_order.py`. Stdlib for enumeration and the
checksum filter, derivation delegated to the folder's own `tools/oracle.py`. It
takes the wordlist by argument or environment rather than vendoring it.
`--size` prints the closed form and checks the layout enumeration against it,
`--selftest` verifies the wordlist digest, measures the checksum acceptance rate
on a real unit, and plants a candidate then requires the pipeline to recover it.
`--run` is resumable and flushes per unit. On a hit it writes the phrase to a
file and does not print it.

One caveat stated plainly: the script's in-run witness re-derives through the
same engine, which is weaker than the 2-engine cross-check the original run
used. That is documented in the function itself rather than glossed over.

## Why this changes the lead ranking

Reading order was the assumption that made the challenge searchable. Dropped,
over the same pool and the same 3 anchors:

```
C(38,4) * C(82,3) * 9! = 73,815 * 88,560 * 362,880 = 2.3722x10^15 arrangements
                                                   = 1.4826x10^14 derivations
                                                   = 5.9 years at 792,000/second
```

The 2 existing sweep leads, liaisons and substrings, are together about 0.2
percent of that. They are still worth running because they are hours rather than
years, but they are no longer plausibly where the answer sits, and the remaining
99.8 percent is not purchasable. So the binding constraint moves from search to
word identification, and the leads are re-ordered to put reading first.

Also included, as evidence rather than a conclusion: inside the reading-order
model, `fog` at 5 and `parrot` at 12 with order preserved force the 4 free video
words to split k before `fog` and m between `fog` and `parrot` with k+m=4. Only
`lake` and `also` lie in that middle range, so m is at most 2, forcing (k,m) to
be (2,2) or (3,1), which forces at least 1 of `lake` and `also` into the phrase.
That whole space is now negative. So either the pool is incomplete on the video
side or order is not preserved. Lead 1 is the cheaper of the 2 to test.

## New lead, ranked first: the text shown on screen in the challenge video

In the challenge video at 5:22 to 5:38 the author says the words "could be you
know written in the video on the screen so read carefully". The written rules in
the hint 5 description agree, listing "description, tags, title, video basically
could be anywhere in this video".

Every sweep in tested.md, including mine, draws its pool from the description,
title, tags and post body. No frame of the video image has been read. That is a
different kind of gap from an unswept corner of a pool that has been read.

There is a concrete reason to expect payload there. The video shows a portfolio
table of holdings, and 10 coin names visible or audible in that segment are
BIP-0039 dictionary words: `atom`, `link`, `dash`, `cash`, `icon`, `wave`,
`gas`, `ocean`, `fetch`, `ripple`. Checked against the 2048-word list, none of
the 10 appears in any recovered 2020 written surface. If even 1 is a list
element, every negative in this folder was drawn from an incomplete pool.

Method for anyone with the video: sample frames at 1 per second, read the text,
intersect with the wordlist, add anything new before re-running. Worth checking
explicitly for `cloud`, which decides established fact 3.

I could not do this myself. My environment has no video download and no optical
character recognition available, and I am not going to route around that. It is
about an hour of ordinary desktop work for someone who can.

## New lead: derivation paths

Every sweep in the folder derives only `m/44'/60'/0'/0/0`. The escrow is stated
to be MetaMask, so that is the right first guess, but if it is the second
account of the same wallet then every negative here is a negative about the
wrong address. Re-checking the already-enumerated survivors at
`m/44'/60'/0'/0/1`, `m/44'/60'/0'/0/2`, `m/44'/60'/1'/0/0` and
`m/44'/60'/2'/0/0` costs about 28 percent of the original derivation work,
because the seed stretch is already done and only the child derivation repeats.
Cheapest decisive experiment currently available in the folder, and never run.

## A correction to an author attribution

This is the part I would most like checked, because it changes an existing lead
rather than adding one.

`analysis/leads.md` lead 2 currently says the author, asked whether a list word
could hide inside a longer written word, "answered yes and gave "possible"
inside its own negation, formed with the prefix "im-", as his own example".

Reading the comment thread directly, that example belongs to the reader who
asked the question, not to the author. The author's reply in full is:

> "1. Yes for example usa could be united states in hints , but wikk have corect
> word in text at chalange. 2 no it doeesnt. 3 it coukd be in any positon from 12
> seed"

His own example is "usa" for "united states", which is an abbreviation, he
offers it about hints, and he contrasts it with the challenge text, which "wikk
have corect word". A second thread has the same shape: asked how the first word
can be "Netherlands" when that is not in the wordlist, he replies "It not
necceseraly need to be exact word if you would read a post you would figure it
our exact word."

Read together the 2 replies describe hints that gloss a word, not text that
conceals one inside another. So the substring mechanism is a reader's hypothesis
the author did not contradict, which is weaker than an author-stated mechanism.
I demoted the lead rather than killing it, and added a second argument against
it: all 5 confirmed list words are whole tokens, none is a substring, which has
probability roughly 0.065 under a simple independent model. I also red-teamed
that argument in the file, because the 5 known words are exactly the ones he
wrote hints for and a hint is easier to write for a whole word, so the sample is
not random.

Both replies are now quoted verbatim in `clues/author-posts.md`, replacing the
paraphrase, so a future reader can judge the attribution without going back to
the comments.

## Smaller corrections

Established fact 3 moves from "`fog` or `cloud`, not settled" to `fog`.
Narrowing hint 3 from "related to water" to its actual wording, condensed water
droplets, leaves `fog`, `cloud` and `vapor`; `vapor` is the gas phase; of the
remaining 2 only `fog` is written anywhere, at index 25 of the video
description. Reservation stated in the file: `cloud` becomes live again if it
turns out to be legible on screen.

The sentence "The text of both the video description and the blog post is
confirmed unchanged since 2020 ... byte for byte" is narrowed. The planted
sentences, title and tags are unchanged, but the description's contact address
was edited from an "info@" form to a "guntis@" form and the rules block grew
with each new hint. Those edits are outside the payload, but somebody diffing
the live page against the archive will hit them and should not read them as
tampering.

## What I did not do

No transcript, article text, forum content or wordlist is added. The new data
file is a derived index of which dictionary words appear in which source range
in written order, 46 words, which is the minimum the script needs to reproduce
the sweep. If you would rather it were computed at runtime from a link, say so
and I will change it.

No absolute paths in any script or document. `python3 tools/validate.py --folder
1-big-prizes/guntis-vitolins-metamask-8-6eth` passes locally for every check
group except the oracle self-test, which cannot run in my environment because
`bip_utils` is not installable there. That is an environment limit, not a change
to `tools/oracle.py`, which is untouched. Please confirm check 11 passes on your
side.

The escrow was not swept and nothing was broadcast. Balance last checked
8.61254155425694462 ETH.
